### PR TITLE
refactor: rename RangeReader parameter constants

### DIFF
--- a/tileverse-rangereader/all/src/test/java/io/tileverse/rangereader/it/RangeReaderFactoryIT.java
+++ b/tileverse-rangereader/all/src/test/java/io/tileverse/rangereader/it/RangeReaderFactoryIT.java
@@ -278,7 +278,7 @@ class RangeReaderFactoryIT {
         RangeReaderConfig config = new RangeReaderConfig().uri(URI.create(url));
 
         if (accountKey != null) {
-            config.setParameter(AzureBlobRangeReaderProvider.ACCOUNT_KEY, accountKey);
+            config.setParameter(AzureBlobRangeReaderProvider.AZURE_ACCOUNT_KEY, accountKey);
         }
 
         return testCreate(config, AzureBlobRangeReader.class);
@@ -301,8 +301,8 @@ class RangeReaderFactoryIT {
                             "Forbidden",
                             "Failed to access S3 object",
                             "Unable to load credentials from any of the providers");
-            config.setParameter(S3RangeReaderProvider.AWS_ACCESS_KEY_ID, accessKey);
-            config.setParameter(S3RangeReaderProvider.AWS_SECRET_ACCESS_KEY, secretKey);
+            config.setParameter(S3RangeReaderProvider.S3_AWS_ACCESS_KEY_ID, accessKey);
+            config.setParameter(S3RangeReaderProvider.S3_AWS_SECRET_ACCESS_KEY, secretKey);
         }
         return testCreate(config, S3RangeReader.class);
     }

--- a/tileverse-rangereader/azure/src/main/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderProvider.java
+++ b/tileverse-rangereader/azure/src/main/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderProvider.java
@@ -68,7 +68,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
 
     /**
      * Creates a new AzureBlobRangeReaderProvider with support for caching parameters
-     * @see AbstractRangeReaderProvider#MEMORY_CACHE
+     * @see AbstractRangeReaderProvider#MEMORY_CACHE_ENABLED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_ALIGNED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_SIZE
      */
@@ -81,7 +81,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
      *
      * @see BlobClientBuilder#blobName(String)
      */
-    public static final RangeReaderParameter<String> BLOB_NAME = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> AZURE_BLOB_NAME = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.azure.blob-name")
             .title("Set the blob name if the endpoint points to the account url")
             .description(
@@ -103,7 +103,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
      * The account access key used to authenticate the request.
      * @see StorageSharedKeyCredential
      */
-    public static final RangeReaderParameter<String> ACCOUNT_KEY = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> AZURE_ACCOUNT_KEY = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.azure.account-key")
             .title("Account access key")
             .description(
@@ -122,7 +122,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
     /**
      * SAS token to use for authenticating requests
      */
-    public static final RangeReaderParameter<String> SAS_TOKEN = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> AZURE_SAS_TOKEN = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.azure.sas-token")
             .title("SAS token to use for authenticating requests")
             .description(
@@ -137,7 +137,8 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
             .subgroup(SUBGROUP_AUTHENTICATION)
             .build();
 
-    private static final List<RangeReaderParameter<?>> PARAMS = List.of(BLOB_NAME, ACCOUNT_KEY, SAS_TOKEN);
+    private static final List<RangeReaderParameter<?>> PARAMS =
+            List.of(AZURE_BLOB_NAME, AZURE_ACCOUNT_KEY, AZURE_SAS_TOKEN);
 
     @Override
     public String getId() {
@@ -181,7 +182,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
         }
         String blobName = parts.getBlobName();
         if (blobName == null) {
-            return config.getParameter(BLOB_NAME).isPresent();
+            return config.getParameter(AZURE_BLOB_NAME).isPresent();
         }
         return true;
     }
@@ -195,9 +196,9 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
     protected RangeReader createInternal(RangeReaderConfig opts) throws IOException {
         URI uri = opts.uri();
         Builder builder = AzureBlobRangeReader.builder().endpoint(uri);
-        opts.getParameter(BLOB_NAME).ifPresent(builder::blobName);
-        opts.getParameter(ACCOUNT_KEY).ifPresent(builder::accountKey);
-        opts.getParameter(SAS_TOKEN).ifPresent(builder::sasToken);
+        opts.getParameter(AZURE_BLOB_NAME).ifPresent(builder::blobName);
+        opts.getParameter(AZURE_ACCOUNT_KEY).ifPresent(builder::accountKey);
+        opts.getParameter(AZURE_SAS_TOKEN).ifPresent(builder::sasToken);
         return builder.build();
     }
 }

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/http/HttpRangeReaderProvider.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/http/HttpRangeReaderProvider.java
@@ -43,7 +43,7 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
 
     /**
      * Creates a new HttpRangeReaderProvider with support for caching parameters
-     * @see AbstractRangeReaderProvider#MEMORY_CACHE
+     * @see AbstractRangeReaderProvider#MEMORY_CACHE_ENABLED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_ALIGNED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_SIZE
      */

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/AbstractRangeReaderProvider.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/AbstractRangeReaderProvider.java
@@ -32,7 +32,7 @@ public abstract class AbstractRangeReaderProvider implements RangeReaderProvider
      * byte range requests. When enabled, a {@link CachingRangeReader} will wrap the
      * underlying {@link RangeReader}.
      */
-    public static final RangeReaderParameter<Boolean> MEMORY_CACHE = CachingProviderHelper.MEMORY_CACHE;
+    public static final RangeReaderParameter<Boolean> MEMORY_CACHE_ENABLED = CachingProviderHelper.MEMORY_CACHE_ENABLED;
 
     /**
      * A {@link RangeReaderParameter} to control whether cached byte ranges should
@@ -50,7 +50,7 @@ public abstract class AbstractRangeReaderProvider implements RangeReaderProvider
      * <p>
      * It also helps in reducing the number of small, fragmented reads.
      * <p>
-     * This setting is only effective when {@link #MEMORY_CACHE caching} is enabled.
+     * This setting is only effective when {@link #MEMORY_CACHE_ENABLED caching} is enabled.
      */
     public static final RangeReaderParameter<Boolean> MEMORY_CACHE_BLOCK_ALIGNED =
             CachingProviderHelper.MEMORY_CACHE_BLOCK_ALIGNED;

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/CachingProviderHelper.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/CachingProviderHelper.java
@@ -34,7 +34,7 @@ class CachingProviderHelper {
      * A {@link RangeReaderParameter} to enable or disable memory caching for raw byte range requests.
      * When enabled, a {@link CachingRangeReader} will wrap the underlying {@link RangeReader}.
      */
-    static final RangeReaderParameter<Boolean> MEMORY_CACHE = RangeReaderParameter.builder()
+    static final RangeReaderParameter<Boolean> MEMORY_CACHE_ENABLED = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.caching.enabled")
             .title("Enable memory cache for raw byte data")
             .description(
@@ -106,7 +106,7 @@ class CachingProviderHelper {
             .build();
 
     private static final List<RangeReaderParameter<?>> PARAMS =
-            List.of(MEMORY_CACHE, MEMORY_CACHE_BLOCK_ALIGNED, MEMORY_CACHE_BLOCK_SIZE);
+            List.of(MEMORY_CACHE_ENABLED, MEMORY_CACHE_BLOCK_ALIGNED, MEMORY_CACHE_BLOCK_SIZE);
 
     /**
      * Returns a new list of parameters that includes the provided parameters along with
@@ -141,7 +141,7 @@ class CachingProviderHelper {
      * @return The decorated {@link RangeReader} (a {@link CachingRangeReader}) or the original reader if caching is disabled.
      */
     public static RangeReader decorate(RangeReader reader, RangeReaderConfig opts) {
-        final boolean enableCaching = opts.getParameter(MEMORY_CACHE).orElse(false);
+        final boolean enableCaching = opts.getParameter(MEMORY_CACHE_ENABLED).orElse(false);
         if (!enableCaching) {
             return reader;
         }

--- a/tileverse-rangereader/gcs/src/main/java/io/tileverse/rangereader/gcs/GoogleCloudStorageRangeReaderProvider.java
+++ b/tileverse-rangereader/gcs/src/main/java/io/tileverse/rangereader/gcs/GoogleCloudStorageRangeReaderProvider.java
@@ -71,7 +71,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
 
     /**
      * Creates a new GoogleCloudStorageRangeReaderProvider with support for caching parameters
-     * @see AbstractRangeReaderProvider#MEMORY_CACHE
+     * @see AbstractRangeReaderProvider#MEMORY_CACHE_ENABLED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_ALIGNED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_SIZE
      */
@@ -82,7 +82,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
     /**
      * Project ID is a unique, user-defined identifier for a Google Cloud project.
      */
-    public static final RangeReaderParameter<String> PROJECT_ID = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> GCS_PROJECT_ID = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.gcs.project-id")
             .title("Google Cloud project ID")
             .description(
@@ -107,7 +107,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
     /**
      * Quota ProjectId that specifies the project used for quota and billing purposes.
      */
-    public static final RangeReaderParameter<String> QUOTA_PROJECT_ID = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> GCS_QUOTA_PROJECT_ID = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.gcs.quota-project-id")
             .title("Quota Project ID")
             .description(
@@ -123,7 +123,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
     /**
      * Use the default application credentials chain, defaults to {@code false}
      */
-    public static final RangeReaderParameter<Boolean> USE_DEFAULT_APPLICTION_CREDENTIALS =
+    public static final RangeReaderParameter<Boolean> GCS_USE_DEFAULT_APPLICTION_CREDENTIALS =
             RangeReaderParameter.builder()
                     .key("io.tileverse.rangereader.gcs.default-credentials-chain")
                     .title("Use the default application credentials chain")
@@ -143,7 +143,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
                     .build();
 
     private static final List<RangeReaderParameter<?>> PARAMS =
-            List.of(PROJECT_ID, QUOTA_PROJECT_ID, USE_DEFAULT_APPLICTION_CREDENTIALS);
+            List.of(GCS_PROJECT_ID, GCS_QUOTA_PROJECT_ID, GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
 
     @Override
     public String getId() {

--- a/tileverse-rangereader/s3/src/main/java/io/tileverse/rangereader/s3/S3RangeReaderProvider.java
+++ b/tileverse-rangereader/s3/src/main/java/io/tileverse/rangereader/s3/S3RangeReaderProvider.java
@@ -79,7 +79,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
 
     /**
      * Creates a new S3RangeReaderProvider with support for caching parameters
-     * @see AbstractRangeReaderProvider#MEMORY_CACHE
+     * @see AbstractRangeReaderProvider#MEMORY_CACHE_ENABLED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_ALIGNED
      * @see AbstractRangeReaderProvider#MEMORY_CACHE_BLOCK_SIZE
      */
@@ -93,7 +93,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
      * addressing will be used instead (e.g., {@code https://bucket.s3.amazonaws.com/key}). This can be useful for
      * compatibility with S3-compatible storage systems that do not support virtual-hosted-style requests.
      */
-    public static final RangeReaderParameter<Boolean> FORCE_PATH_STYLE = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<Boolean> S3_FORCE_PATH_STYLE = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.s3.force-path-style")
             .title("Enable S3 path style access")
             .description(
@@ -116,7 +116,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
             .build();
 
     /** Configuration parameter for AWS S3 region. */
-    public static final RangeReaderParameter<String> REGION = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> S3_REGION = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.s3.region")
             .title("Region")
             .description(
@@ -149,7 +149,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
     /**
      * The AWS access key ID to use for authentication when both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are provided.
      */
-    public static final RangeReaderParameter<String> AWS_ACCESS_KEY_ID = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> S3_AWS_ACCESS_KEY_ID = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.s3.aws-access-key-id")
             .title("AWS Access Key ID")
             .description(
@@ -170,7 +170,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
     /**
      * The AWS secret access key to use for authentication when both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are provided.
      */
-    public static final RangeReaderParameter<String> AWS_SECRET_ACCESS_KEY = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> S3_AWS_SECRET_ACCESS_KEY = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.s3.aws-secret-access-key")
             .title("AWS Secret Access Key")
             .description(
@@ -189,11 +189,12 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
             .build();
 
     /** Configuration parameter to control whether to use the default AWS credentials provider chain. */
-    public static final RangeReaderParameter<Boolean> USE_DEFAULT_CREDENTIALS_PROVIDER = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.use-default-credentials-provider")
-            .title("Use Default Credentials Provider")
-            .description(
-                    """
+    public static final RangeReaderParameter<Boolean> S3_USE_DEFAULT_CREDENTIALS_PROVIDER =
+            RangeReaderParameter.builder()
+                    .key("io.tileverse.rangereader.s3.use-default-credentials-provider")
+                    .title("Use Default Credentials Provider")
+                    .description(
+                            """
                     When enabled, the AWS default credentials provider chain is used, which looks for credentials \
                     in this order:
                       1. Java System Properties - aws.accessKeyId and aws.secretAccessKey
@@ -206,13 +207,13 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
                     If neither default credentials provider or access/secret key are used, annonymous access will \
                     be attempted.
                     """)
-            .type(Boolean.class)
-            .group(ID)
-            .subgroup(SUBGROUP_AUTHENTICATION)
-            .build();
+                    .type(Boolean.class)
+                    .group(ID)
+                    .subgroup(SUBGROUP_AUTHENTICATION)
+                    .build();
 
     /** Configuration parameter to specify a custom AWS credentials profile name. */
-    public static final RangeReaderParameter<String> DEFAULT_CREDENTIALS_PROFILE = RangeReaderParameter.builder()
+    public static final RangeReaderParameter<String> S3_DEFAULT_CREDENTIALS_PROFILE = RangeReaderParameter.builder()
             .key("io.tileverse.rangereader.s3.default-credentials-profile")
             .title("Default Credentials Profile")
             .description(
@@ -231,12 +232,12 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
             .build();
 
     static final List<RangeReaderParameter<?>> PARAMS = List.of(
-            FORCE_PATH_STYLE,
-            REGION,
-            AWS_ACCESS_KEY_ID,
-            AWS_SECRET_ACCESS_KEY,
-            USE_DEFAULT_CREDENTIALS_PROVIDER,
-            DEFAULT_CREDENTIALS_PROFILE);
+            S3_FORCE_PATH_STYLE,
+            S3_REGION,
+            S3_AWS_ACCESS_KEY_ID,
+            S3_AWS_SECRET_ACCESS_KEY,
+            S3_USE_DEFAULT_CREDENTIALS_PROVIDER,
+            S3_DEFAULT_CREDENTIALS_PROFILE);
 
     @Override
     public String getId() {
@@ -272,12 +273,12 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
     Builder prepareRangeReaderBuilder(RangeReaderConfig opts) {
         URI uri = opts.uri();
         Builder builder = S3RangeReader.builder().uri(uri);
-        opts.getParameter(FORCE_PATH_STYLE).ifPresent(builder::forcePathStyle);
-        opts.getParameter(REGION).filter(r -> !r.isBlank()).map(Region::of).ifPresent(builder::region);
-        opts.getParameter(AWS_ACCESS_KEY_ID).ifPresent(builder::awsAccessKeyId);
-        opts.getParameter(AWS_SECRET_ACCESS_KEY).ifPresent(builder::awsSecretAccessKey);
-        opts.getParameter(USE_DEFAULT_CREDENTIALS_PROVIDER).ifPresent(builder::useDefaultCredentialsProvider);
-        opts.getParameter(DEFAULT_CREDENTIALS_PROFILE).ifPresent(builder::defaultCredentialsProfile);
+        opts.getParameter(S3_FORCE_PATH_STYLE).ifPresent(builder::forcePathStyle);
+        opts.getParameter(S3_REGION).filter(r -> !r.isBlank()).map(Region::of).ifPresent(builder::region);
+        opts.getParameter(S3_AWS_ACCESS_KEY_ID).ifPresent(builder::awsAccessKeyId);
+        opts.getParameter(S3_AWS_SECRET_ACCESS_KEY).ifPresent(builder::awsSecretAccessKey);
+        opts.getParameter(S3_USE_DEFAULT_CREDENTIALS_PROVIDER).ifPresent(builder::useDefaultCredentialsProvider);
+        opts.getParameter(S3_DEFAULT_CREDENTIALS_PROFILE).ifPresent(builder::defaultCredentialsProfile);
         return builder;
     }
 

--- a/tileverse-rangereader/s3/src/test/java/io/tileverse/rangereader/s3/S3RangeReaderProviderTest.java
+++ b/tileverse-rangereader/s3/src/test/java/io/tileverse/rangereader/s3/S3RangeReaderProviderTest.java
@@ -16,9 +16,9 @@
 package io.tileverse.rangereader.s3;
 
 import static io.tileverse.rangereader.s3.S3RangeReaderProvider.*;
-import static io.tileverse.rangereader.s3.S3RangeReaderProvider.AWS_SECRET_ACCESS_KEY;
-import static io.tileverse.rangereader.s3.S3RangeReaderProvider.FORCE_PATH_STYLE;
-import static io.tileverse.rangereader.s3.S3RangeReaderProvider.REGION;
+import static io.tileverse.rangereader.s3.S3RangeReaderProvider.S3_AWS_SECRET_ACCESS_KEY;
+import static io.tileverse.rangereader.s3.S3RangeReaderProvider.S3_FORCE_PATH_STYLE;
+import static io.tileverse.rangereader.s3.S3RangeReaderProvider.S3_REGION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
@@ -88,12 +88,12 @@ class S3RangeReaderProviderTest {
         List<RangeReaderParameter<?>> parameters = provider.buildParameters();
         assertThat(parameters)
                 .isEqualTo(List.of(
-                        FORCE_PATH_STYLE,
-                        REGION,
-                        AWS_ACCESS_KEY_ID,
-                        AWS_SECRET_ACCESS_KEY,
-                        USE_DEFAULT_CREDENTIALS_PROVIDER,
-                        DEFAULT_CREDENTIALS_PROFILE));
+                        S3_FORCE_PATH_STYLE,
+                        S3_REGION,
+                        S3_AWS_ACCESS_KEY_ID,
+                        S3_AWS_SECRET_ACCESS_KEY,
+                        S3_USE_DEFAULT_CREDENTIALS_PROVIDER,
+                        S3_DEFAULT_CREDENTIALS_PROFILE));
     }
 
     @Test
@@ -206,7 +206,7 @@ class S3RangeReaderProviderTest {
         // The FORCE_PATH_STYLE parameter doesn't affect canProcess() anymore
         // because the URL parsing now automatically detects the required style
 
-        config.setParameter(FORCE_PATH_STYLE.key(), false);
+        config.setParameter(S3_FORCE_PATH_STYLE.key(), false);
         // These should still work because the parser detects the URL format
         assertThat(provider.canProcess(config.uri("http://localhost:9000/my-bucket/file.txt")))
                 .as("MinIO URLs work regardless of force-path-style setting")
@@ -215,7 +215,7 @@ class S3RangeReaderProviderTest {
                 .as("AWS virtual hosted-style URLs work regardless of force-path-style setting")
                 .isTrue();
 
-        config.setParameter(FORCE_PATH_STYLE.key(), true);
+        config.setParameter(S3_FORCE_PATH_STYLE.key(), true);
         assertThat(provider.canProcess(config.uri("http://localhost:9000/my-bucket/file.txt")))
                 .as("MinIO URLs work regardless of force-path-style setting")
                 .isTrue();
@@ -279,7 +279,7 @@ class S3RangeReaderProviderTest {
         RangeReaderConfig capturedConfig = configCaptor.getValue();
         assertThat(capturedConfig.uri()).isEqualTo(testUri);
         //        assertThat(capturedConfig.providerId()).isEqualTo("s3");
-        assertThat(capturedConfig.getParameter(FORCE_PATH_STYLE)).hasValue(true);
+        assertThat(capturedConfig.getParameter(S3_FORCE_PATH_STYLE)).hasValue(true);
     }
 
     @Test
@@ -296,10 +296,10 @@ class S3RangeReaderProviderTest {
                 .hasFieldOrPropertyWithValue("s3Location.bucket", "my-bucket")
                 .hasFieldOrPropertyWithValue("s3Location.key", "file.txt");
 
-        config.setParameter(FORCE_PATH_STYLE, true);
-        config.setParameter(REGION, "us-west-2");
-        config.setParameter(AWS_ACCESS_KEY_ID, "access-key");
-        config.setParameter(AWS_SECRET_ACCESS_KEY, "secret-key");
+        config.setParameter(S3_FORCE_PATH_STYLE, true);
+        config.setParameter(S3_REGION, "us-west-2");
+        config.setParameter(S3_AWS_ACCESS_KEY_ID, "access-key");
+        config.setParameter(S3_AWS_SECRET_ACCESS_KEY, "secret-key");
 
         rangeReaderBuilder = provider.prepareRangeReaderBuilder(config);
         assertThat(rangeReaderBuilder)


### PR DESCRIPTION
Include provider prefix hint in constant names