### PR TITLE
Enforce try-with-resources for ByteBufferPool via PooledByteBuffer wrapper

### DIFF
--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
@@ -539,17 +539,15 @@ public record PMTilesHeader(
 
     static PMTilesHeader readHeader(ReadableByteChannel channel) throws IOException, InvalidHeaderException {
         // Read the header
-        ByteBuffer headerBuffer = ByteBufferPool.getDefault().borrowHeap(127);
-        try {
-            int bytesRead = channel.read(headerBuffer);
+        try (var pooledBuffer = ByteBufferPool.heapBuffer(127)) {
+            ByteBuffer buffer = pooledBuffer.buffer();
+            int bytesRead = channel.read(buffer);
             if (bytesRead != 127) {
                 throw new InvalidHeaderException("Failed to read complete header. Read " + bytesRead + " bytes");
             }
-            headerBuffer.flip();
+            buffer.flip();
             // Deserialize the header directly from the ByteBuffer
-            return deserialize(headerBuffer);
-        } finally {
-            ByteBufferPool.getDefault().returnBuffer(headerBuffer);
+            return deserialize(buffer);
         }
     }
 }

--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesReader.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesReader.java
@@ -509,16 +509,15 @@ public class PMTilesReader {
     }
 
     private ByteBuffer readData(ByteRange range, byte compression) {
-        ByteBuffer buffer = ByteBufferPool.getDefault().borrowHeap(range.length());
-        try (SeekableByteChannel channel = channelSupplier.get()) {
+        try (SeekableByteChannel channel = channelSupplier.get();
+                var pooledBuffer = ByteBufferPool.heapBuffer(range.length())) {
+            ByteBuffer buffer = pooledBuffer.buffer();
             channel.position(range.offset());
             channel.read(buffer);
             buffer.flip();
             return CompressionUtil.decompress(buffer, compression);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        } finally {
-            ByteBufferPool.getDefault().returnBuffer(buffer);
         }
     }
 

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/block/BlockAlignedRangeReader.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/block/BlockAlignedRangeReader.java
@@ -120,9 +120,8 @@ public class BlockAlignedRangeReader extends AbstractRangeReader implements Rang
         }
 
         // Keep a small working buffer to read blocks
-        final ByteBufferPool pool = ByteBufferPool.getDefault();
-        final ByteBuffer blockBuffer = pool.borrowDirect(blockSize);
-        try {
+        try (var pooled = ByteBufferPool.directBuffer(blockSize)) {
+            ByteBuffer blockBuffer = pooled.buffer();
             // Position tracking for partial blocks
             int bytesRemaining = actualLength;
 
@@ -172,8 +171,6 @@ public class BlockAlignedRangeReader extends AbstractRangeReader implements Rang
             // Calculate how many bytes were actually read
             int bytesRead = actualLength - bytesRemaining;
             return bytesRead;
-        } finally {
-            pool.returnBuffer(blockBuffer);
         }
     }
 

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/cache/DiskCachingRangeReader.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/cache/DiskCachingRangeReader.java
@@ -657,9 +657,8 @@ public class DiskCachingRangeReader extends AbstractRangeReader implements Range
         logger.debug("Cache miss for key: offset={}, length={}", key.offset(), key.length());
 
         // Read the data from the delegate
-        ByteBufferPool pool = ByteBufferPool.getDefault();
-        ByteBuffer buffer = pool.borrowDirect(key.length());
-        try {
+        try (var pooled = ByteBufferPool.directBuffer(key.length())) {
+            ByteBuffer buffer = pooled.buffer();
             int bytesRead = delegate.readRange(key.offset(), key.length(), buffer);
 
             // It's acceptable to read fewer bytes if we reached EOF
@@ -698,8 +697,6 @@ public class DiskCachingRangeReader extends AbstractRangeReader implements Range
             }
             logger.debug("Added to disk cache: offset={}, length={}, path={}", key.offset(), key.length(), cachePath);
             return cachePath;
-        } finally {
-            pool.returnBuffer(buffer);
         }
     }
 


### PR DESCRIPTION
Replace direct ByteBuffer returns with PooledByteBuffer (AutoCloseable) to ensure buffers are always returned to the pool via try-with-resources.

Changes:
- borrowDirect/borrowHeap now return PooledByteBuffer instead of ByteBuffer
- Add static convenience methods: directBuffer(int), heapBuffer(int)
- Return buffer slices matching requested capacity (not pooled buffer capacity)
- Update all tests to use try-with-resources pattern

Additional improvements:
- Unify minBufferSize and 8KB rounding into single blockSize parameter
- Change default from 4KB min/8KB rounding to 8KB block size

This prevents resource leaks and makes the pool safer to use.