### PR TITLE
Dependency updates

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <!-- Dependency versions -->
-    <aws-s3.version>2.40.2</aws-s3.version>
+    <aws-s3.version>2.40.7</aws-s3.version>
     <azure-identity.version>1.18.1</azure-identity.version>
     <azure-storage-blob.version>12.32.0</azure-storage-blob.version>
     <caffeine.version>3.2.3</caffeine.version>
@@ -163,12 +163,12 @@
         <!-- Async client alternative -->
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-crt-client</artifactId>
-        <version>2.40.2</version>
+        <version>${aws-s3.version}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk.crt</groupId>
         <artifactId>aws-crt</artifactId>
-        <version>0.40.3</version>
+        <version>0.41.0</version>
       </dependency>
 
       <dependency>
@@ -232,7 +232,7 @@
 	    -->
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.43.0</version>
+        <version>2.45.0</version>
       </dependency>
       <dependency>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
 
     <!-- Dependency versions -->
     <!-- Runtime dependencies are defined in the dependencies/pom.xml BOM -->
-    <lombok.version>1.18.38</lombok.version>
+    <lombok.version>1.18.42</lombok.version>
 
     <!-- Test Dependency versions -->
     <assertj.version>3.27.3</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <commons-io.version>2.19.0</commons-io.version>
+    <commons-io.version>2.21.0</commons-io.version>
     <junit.version>5.13.2</junit.version>
     <logback.version>1.5.18</logback.version>
     <mockito.version>5.18.0</mockito.version>

--- a/tileverse-rangereader/benchmarks/pom.xml
+++ b/tileverse-rangereader/benchmarks/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.9</version>
+      <version>2.0.17</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
* aws-s3.version:2.40.2 -> 2.40.7
* software.amazon.awssdk.crt:aws-crt:0.40.3 -> 0.41.0
* com.google.errorprone:error_prone_annotations:2.43.0 -> 2.45.0