### PR TITLE
Align GeoParquet datastore cloud configuration, tests, and coverage

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -60,6 +60,16 @@
       <groupId>io.tileverse.pmtiles</groupId>
       <artifactId>tileverse-pmtiles</artifactId>
     </dependency>
+
+    <!-- Parquet modules -->
+    <dependency>
+      <groupId>io.tileverse.parquet</groupId>
+      <artifactId>tileverse-parquet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.tileverse.parquet</groupId>
+      <artifactId>tileverse-parquet-datastore</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tileverse-parquet-datastore/pom.xml
+++ b/tileverse-parquet-datastore/pom.xml
@@ -46,6 +46,13 @@
       <groupId>io.tileverse.parquet</groupId>
       <artifactId>tileverse-parquet</artifactId>
     </dependency>
+    <!-- Required at compile and Javadoc time because the datastore uses Avro GenericRecord
+         types in its production code, not only through transitive parquet-avro internals. -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.11.5</version>
+    </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
@@ -63,6 +70,27 @@
       <groupId>io.tileverse.rangereader</groupId>
       <artifactId>tileverse-rangereader-core</artifactId>
     </dependency>
+    <!-- Required at compile time because GeoParquet exposes the same datastore parameters
+         as the RangeReader-backed providers and references their parameter definitions. -->
+    <dependency>
+      <groupId>io.tileverse.rangereader</groupId>
+      <artifactId>tileverse-rangereader-s3</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <!-- Required at compile time because GeoParquet exposes the same datastore parameters
+         as the RangeReader-backed providers and references their parameter definitions. -->
+    <dependency>
+      <groupId>io.tileverse.rangereader</groupId>
+      <artifactId>tileverse-rangereader-azure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <!-- Required at compile time because GeoParquet exposes the same datastore parameters
+         as the RangeReader-backed providers and references their parameter definitions. -->
+    <dependency>
+      <groupId>io.tileverse.rangereader</groupId>
+      <artifactId>tileverse-rangereader-gcs</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>io.tileverse.parquet</groupId>
@@ -74,6 +102,44 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for the Hadoop-backed performance IT that exercises parquet-hadoop readers. -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for the fake-GCS-backed integration test because the Google Storage client uses
+         the full protobuf runtime (e.g. com.google.protobuf.Any), not protobuf-javalite. -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf-java.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for integration tests that use Testcontainers with JUnit 5. -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for the MinIO-backed integration test that verifies parameterized S3 access. -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>minio</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for the Azurite-backed integration test that verifies parameterized Azure Blob access. -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>azure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed only for the fake-GCS-backed integration test that verifies parameterized Google Cloud Storage access. -->
+    <dependency>
+      <groupId>io.aiven</groupId>
+      <artifactId>testcontainers-fake-gcs-server</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactory.java
+++ b/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactory.java
@@ -21,12 +21,22 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.FileDataStore;
 import org.geotools.api.data.FileDataStoreFactorySpi;
 import org.geotools.util.logging.Logging;
 
+/**
+ * Read-only GeoParquet datastore factory backed by Tileverse {@code RangeReader}s.
+ *
+ * <p>Besides the mandatory {@value #URL_PARAM} parameter, this factory exposes the same
+ * cloud/backend/authentication parameters used by the PMTiles datastore so GeoParquet can be
+ * opened consistently from local files, HTTP, S3-compatible storage, Azure Blob Storage, and
+ * Google Cloud Storage.
+ */
 public class GeoParquetFileDataStoreFactory implements FileDataStoreFactorySpi {
 
     private static final Logger LOGGER = Logging.getLogger(GeoParquetFileDataStoreFactory.class);
@@ -46,13 +56,14 @@ public class GeoParquetFileDataStoreFactory implements FileDataStoreFactorySpi {
 
     @Override
     public String getDescription() {
-        return "GeoParquet pure java";
+        return "GeoParquet backed by Tileverse RangeReader";
     }
 
     @Override
     public DataStore createDataStore(Map<String, ?> params) throws IOException {
         URL url = toUrl(params.get(URL_PARAM));
-        return createDataStore(url);
+        Properties rangeReaderConfig = GeoParquetRangeReaderParams.toProperties(params);
+        return GeoparquetContentDataStore.open(url, rangeReaderConfig);
     }
 
     @Override
@@ -62,7 +73,9 @@ public class GeoParquetFileDataStoreFactory implements FileDataStoreFactorySpi {
 
     @Override
     public Param[] getParametersInfo() {
-        return new Param[] {URLP};
+        // Keep the GeoParquet URL first, then expose the provider-backed RangeReader connection/auth params.
+        return Stream.concat(Stream.of(URLP), Stream.of(GeoParquetRangeReaderParams.getParameters()))
+                .toArray(Param[]::new);
     }
 
     @Override

--- a/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoParquetRangeReaderParams.java
+++ b/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoParquetRangeReaderParams.java
@@ -1,0 +1,161 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.geotools.parquet;
+
+import io.tileverse.rangereader.azure.AzureBlobRangeReaderProvider;
+import io.tileverse.rangereader.gcs.GoogleCloudStorageRangeReaderProvider;
+import io.tileverse.rangereader.http.HttpRangeReaderProvider;
+import io.tileverse.rangereader.s3.S3RangeReaderProvider;
+import io.tileverse.rangereader.spi.AbstractRangeReaderProvider;
+import io.tileverse.rangereader.spi.RangeReaderConfig;
+import io.tileverse.rangereader.spi.RangeReaderParameter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.geotools.api.data.DataAccessFactory.Param;
+import org.geotools.api.data.Parameter;
+import org.geotools.util.Converters;
+
+/**
+ * Internal helper for the GeoParquet datastore factory to expose and translate RangeReader
+ * parameters.
+ *
+ * <p>The GeoParquet datastore is backed by Tileverse {@code RangeReader}s, so it needs to expose
+ * the same backend and authentication options understood by the available RangeReader providers.
+ * This helper keeps that mapping local to the GeoParquet implementation:
+ *
+ * <ul>
+ *   <li>it publishes provider-backed parameters as GeoTools {@link Param}s for the factory</li>
+ *   <li>it translates the GeoTools connection map back to {@link Properties} for
+ *   {@code RangeReaderFactory}</li>
+ * </ul>
+ *
+ * <p>If another Tileverse GeoTools datastore ends up needing the same bridge, this class can be
+ * extracted to a shared integration package without changing the GeoParquet factory contract.
+ */
+final class GeoParquetRangeReaderParams {
+
+    static final Param RANGEREADER_PROVIDER_ID = dataStoreParam(RangeReaderConfig.FORCE_PROVIDER_ID);
+
+    static final Param MEMORY_CACHE_ENABLED = dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_ENABLED);
+    static final Param MEMORY_CACHE_BLOCK_ALIGNED =
+            dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_ALIGNED);
+    static final Param MEMORY_CACHE_BLOCK_SIZE = dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_SIZE);
+
+    static final Param HTTP_CONNECTION_TIMEOUT_MILLIS =
+            dataStoreParam(HttpRangeReaderProvider.HTTP_CONNECTION_TIMEOUT_MILLIS);
+    static final Param HTTP_TRUST_ALL_SSL_CERTIFICATES =
+            dataStoreParam(HttpRangeReaderProvider.HTTP_TRUST_ALL_SSL_CERTIFICATES);
+    static final Param HTTP_AUTH_USERNAME = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_USERNAME);
+    static final Param HTTP_AUTH_PASSWORD = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_PASSWORD);
+    static final Param HTTP_AUTH_BEARER_TOKEN = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_BEARER_TOKEN);
+    static final Param HTTP_AUTH_API_KEY_HEADERNAME =
+            dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY_HEADERNAME);
+    static final Param HTTP_AUTH_API_KEY = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY);
+    static final Param HTTP_AUTH_API_KEY_VALUE_PREFIX =
+            dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY_VALUE_PREFIX);
+
+    static final Param AZURE_BLOB_NAME = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_BLOB_NAME);
+    static final Param AZURE_ACCOUNT_KEY = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_ACCOUNT_KEY);
+    static final Param AZURE_SAS_TOKEN = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_SAS_TOKEN);
+
+    static final Param S3_FORCE_PATH_STYLE = dataStoreParam(S3RangeReaderProvider.S3_FORCE_PATH_STYLE);
+    static final Param S3_REGION = dataStoreParam(S3RangeReaderProvider.S3_REGION);
+    static final Param S3_AWS_ACCESS_KEY_ID = dataStoreParam(S3RangeReaderProvider.S3_AWS_ACCESS_KEY_ID);
+    static final Param S3_AWS_SECRET_ACCESS_KEY = dataStoreParam(S3RangeReaderProvider.S3_AWS_SECRET_ACCESS_KEY);
+    static final Param S3_USE_DEFAULT_CREDENTIALS_PROVIDER =
+            dataStoreParam(S3RangeReaderProvider.S3_USE_DEFAULT_CREDENTIALS_PROVIDER);
+    static final Param S3_DEFAULT_CREDENTIALS_PROFILE =
+            dataStoreParam(S3RangeReaderProvider.S3_DEFAULT_CREDENTIALS_PROFILE);
+
+    static final Param GCS_PROJECT_ID = dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_PROJECT_ID);
+    static final Param GCS_QUOTA_PROJECT_ID =
+            dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_QUOTA_PROJECT_ID);
+    static final Param GCS_USE_DEFAULT_APPLICTION_CREDENTIALS =
+            dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
+
+    static final List<Param> PARAMETERS = List.of(
+            RANGEREADER_PROVIDER_ID,
+            MEMORY_CACHE_ENABLED,
+            MEMORY_CACHE_BLOCK_ALIGNED,
+            MEMORY_CACHE_BLOCK_SIZE,
+            HTTP_CONNECTION_TIMEOUT_MILLIS,
+            HTTP_TRUST_ALL_SSL_CERTIFICATES,
+            HTTP_AUTH_USERNAME,
+            HTTP_AUTH_PASSWORD,
+            HTTP_AUTH_BEARER_TOKEN,
+            HTTP_AUTH_API_KEY_HEADERNAME,
+            HTTP_AUTH_API_KEY,
+            HTTP_AUTH_API_KEY_VALUE_PREFIX,
+            AZURE_BLOB_NAME,
+            AZURE_ACCOUNT_KEY,
+            AZURE_SAS_TOKEN,
+            S3_FORCE_PATH_STYLE,
+            S3_REGION,
+            S3_AWS_ACCESS_KEY_ID,
+            S3_AWS_SECRET_ACCESS_KEY,
+            S3_USE_DEFAULT_CREDENTIALS_PROVIDER,
+            S3_DEFAULT_CREDENTIALS_PROFILE,
+            GCS_PROJECT_ID,
+            GCS_QUOTA_PROJECT_ID,
+            GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
+
+    private GeoParquetRangeReaderParams() {}
+
+    static Param[] getParameters() {
+        return PARAMETERS.toArray(Param[]::new);
+    }
+
+    static Properties toProperties(Map<String, ?> connectionParams) {
+        Properties config = new Properties();
+        PARAMETERS.forEach(param -> addProperty(param, connectionParams, config));
+        return config;
+    }
+
+    private static void addProperty(Param param, Map<String, ?> params, Properties config) {
+        Object value;
+        try {
+            value = param.lookUp(params);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (value != null) {
+            config.setProperty(param.key, Converters.convert(value, String.class));
+        }
+    }
+
+    private static Param dataStoreParam(RangeReaderParameter<?> param) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(Parameter.LEVEL, param.group());
+        if (param.password()) {
+            metadata.put(Parameter.IS_PASSWORD, Boolean.TRUE);
+        }
+        if (!param.sampleValues().isEmpty()) {
+            metadata.put(Parameter.OPTIONS, param.sampleValues().toArray());
+        }
+
+        return new Param(
+                param.key(),
+                param.type(),
+                param.description(),
+                false,
+                param.defaultValue().orElse(null),
+                metadata);
+    }
+}

--- a/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoparquetContentDataStore.java
+++ b/tileverse-parquet-datastore/src/main/java/io/tileverse/geotools/parquet/GeoparquetContentDataStore.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -88,10 +89,20 @@ public class GeoparquetContentDataStore extends ContentDataStore implements File
     }
 
     public static GeoparquetContentDataStore open(URL url) throws IOException {
-        return open(url, TileverseParquetRecordSource::new);
+        return open(url, new Properties());
+    }
+
+    public static GeoparquetContentDataStore open(URL url, Properties rangeReaderConfig) throws IOException {
+        return open(url, rangeReaderConfig, TileverseParquetRecordSource::new);
     }
 
     public static GeoparquetContentDataStore open(URL url, GeoParquetRecordSourceFactory recordSourceFactory)
+            throws IOException {
+        return open(url, new Properties(), recordSourceFactory);
+    }
+
+    static GeoparquetContentDataStore open(
+            URL url, Properties rangeReaderConfig, GeoParquetRecordSourceFactory recordSourceFactory)
             throws IOException {
         Objects.requireNonNull(recordSourceFactory, "recordSourceFactory");
         URI uri;
@@ -100,7 +111,8 @@ public class GeoparquetContentDataStore extends ContentDataStore implements File
         } catch (URISyntaxException e) {
             throw new IOException(e);
         }
-        RangeReader rangeReader = RangeReaderFactory.create(uri);
+        Properties config = rangeReaderConfig == null ? new Properties() : rangeReaderConfig;
+        RangeReader rangeReader = RangeReaderFactory.create(uri, config);
         try {
             GeoParquetRecordSource recordSource = recordSourceFactory.create(rangeReader);
             return new GeoparquetContentDataStore(uri, rangeReader, recordSource);

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetDatastoreCloudITSupport.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetDatastoreCloudITSupport.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import org.geotools.api.data.DataStore;
+import org.geotools.data.simple.SimpleFeatureCollection;
+
+final class GeoParquetDatastoreCloudITSupport {
+
+    static final String FIXTURE_RESOURCE = "/geoparquet/sample-geoparquet.parquet";
+    static final String OBJECT_NAME = "sample-geoparquet.parquet";
+    static final String TYPE_NAME = "sample-geoparquet";
+    static final GeoParquetFileDataStoreFactory FACTORY = new GeoParquetFileDataStoreFactory();
+
+    private GeoParquetDatastoreCloudITSupport() {}
+
+    static Path extractFixture(Class<?> testClass, Path tempDir) {
+        try (InputStream in = testClass.getResourceAsStream(FIXTURE_RESOURCE)) {
+            assertThat(in).as("Missing fixture resource %s", FIXTURE_RESOURCE).isNotNull();
+            Path fixture = tempDir.resolve(OBJECT_NAME);
+            Files.copy(in, fixture, StandardCopyOption.REPLACE_EXISTING);
+            return fixture;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    static void assertReadsSampleGeoParquet(Map<String, Object> params) throws IOException {
+        DataStore dataStore = FACTORY.createDataStore(params);
+        try {
+            assertThat(dataStore.getTypeNames()).containsExactly(TYPE_NAME);
+            SimpleFeatureCollection features =
+                    dataStore.getFeatureSource(TYPE_NAME).getFeatures();
+            assertThat(features.size()).isEqualTo(3);
+        } finally {
+            dataStore.dispose();
+        }
+    }
+
+    static void assertReadsSampleGeoParquet(URL url, Map<String, Object> extraParams) throws IOException {
+        java.util.LinkedHashMap<String, Object> params = new java.util.LinkedHashMap<>();
+        params.put("url", url);
+        params.putAll(extraParams);
+        assertReadsSampleGeoParquet(params);
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryAzuriteIT.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryAzuriteIT.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.azure.AzuriteContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class GeoParquetFileDataStoreFactoryAzuriteIT {
+
+    private static final String ACCOUNT_NAME = "devstoreaccount1";
+    private static final String ACCOUNT_KEY =
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    private static final String CONTAINER_NAME = "geoparquet-it";
+
+    @Container
+    @SuppressWarnings("resource")
+    static AzuriteContainer azurite = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.35.0")
+            .withCommand("azurite-blob --skipApiVersionCheck --loose --blobHost 0.0.0.0 --debug")
+            .withExposedPorts(10000, 10001, 10002);
+
+    private static URL azuriteFixtureUrl;
+
+    @BeforeAll
+    static void setupAzurite(@TempDir Path tempDir) throws Exception {
+        Path parquetFixture = GeoParquetDatastoreCloudITSupport.extractFixture(
+                GeoParquetFileDataStoreFactoryAzuriteIT.class, tempDir);
+        uploadFixture(parquetFixture);
+        String endpoint = "http://%s:%d/%s/%s/%s"
+                .formatted(
+                        azurite.getHost(),
+                        azurite.getMappedPort(10000),
+                        ACCOUNT_NAME,
+                        CONTAINER_NAME,
+                        GeoParquetDatastoreCloudITSupport.OBJECT_NAME);
+        azuriteFixtureUrl = new URL(endpoint);
+    }
+
+    @Test
+    void createDataStore_requiresAzureConnectionParametersForAzuriteHttpUrl() {
+        assertThatThrownBy(() ->
+                        GeoParquetDatastoreCloudITSupport.FACTORY.createDataStore(Map.of("url", azuriteFixtureUrl)))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void createDataStore_readsParquetThroughParameterizedAzureRangeReader() throws Exception {
+        Map<String, Object> params = Map.of(
+                "url",
+                azuriteFixtureUrl,
+                "io.tileverse.rangereader.provider",
+                "azure",
+                "io.tileverse.rangereader.azure.account-key",
+                ACCOUNT_KEY);
+
+        GeoParquetDatastoreCloudITSupport.assertReadsSampleGeoParquet(params);
+    }
+
+    private static void uploadFixture(Path parquetFixture) {
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .connectionString(azurite.getConnectionString())
+                .buildClient();
+        BlobContainerClient containerClient = blobServiceClient.createBlobContainer(CONTAINER_NAME);
+        containerClient
+                .getBlobClient(GeoParquetDatastoreCloudITSupport.OBJECT_NAME)
+                .uploadFromFile(parquetFixture.toString(), true);
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryGcsIT.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryGcsIT.java
@@ -1,0 +1,113 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ */
+package io.tileverse.geotools.parquet;
+
+import com.google.auth.Credentials;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class GeoParquetFileDataStoreFactoryGcsIT {
+
+    private static final String BUCKET_NAME = "geoparquet-it";
+    private static final String PROJECT_ID = "test-project";
+    private static final Credentials NO_CREDENTIALS = new Credentials() {
+        @Override
+        public String getAuthenticationType() {
+            return "None";
+        }
+
+        @Override
+        public Map<String, List<String>> getRequestMetadata(java.net.URI uri) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean hasRequestMetadata() {
+            return false;
+        }
+
+        @Override
+        public boolean hasRequestMetadataOnly() {
+            return false;
+        }
+
+        @Override
+        public void refresh() {
+            // no-op for emulator access
+        }
+    };
+
+    @Container
+    static FakeGcsServerContainer gcsEmulator = new FakeGcsServerContainer();
+
+    private static URL gcsFixtureUrl;
+
+    @BeforeAll
+    static void setupGcs(@TempDir Path tempDir) throws Exception {
+        Path parquetFixture =
+                GeoParquetDatastoreCloudITSupport.extractFixture(GeoParquetFileDataStoreFactoryGcsIT.class, tempDir);
+        uploadFixture(parquetFixture);
+        String emulatorUrl = "http://%s:%d/storage/v1/b/%s/o/%s?alt=media"
+                .formatted(
+                        gcsEmulator.getHost(),
+                        gcsEmulator.getFirstMappedPort(),
+                        BUCKET_NAME,
+                        GeoParquetDatastoreCloudITSupport.OBJECT_NAME);
+        gcsFixtureUrl = new URL(emulatorUrl);
+    }
+
+    @Test
+    void createDataStore_readsParquetThroughParameterizedGcsRangeReader() throws Exception {
+        Map<String, Object> params = Map.of(
+                "url",
+                gcsFixtureUrl,
+                "io.tileverse.rangereader.provider",
+                "gcs",
+                "io.tileverse.rangereader.gcs.project-id",
+                PROJECT_ID,
+                "io.tileverse.rangereader.gcs.default-credentials-chain",
+                false);
+
+        GeoParquetDatastoreCloudITSupport.assertReadsSampleGeoParquet(params);
+    }
+
+    private static void uploadFixture(Path parquetFixture) throws IOException {
+        String emulatorEndpoint = "http://" + gcsEmulator.getHost() + ":" + gcsEmulator.getFirstMappedPort();
+        Storage storage = StorageOptions.newBuilder()
+                .setProjectId(PROJECT_ID)
+                .setHost(emulatorEndpoint)
+                .setCredentials(NO_CREDENTIALS)
+                .build()
+                .getService();
+        try {
+            storage.create(BucketInfo.newBuilder(BUCKET_NAME).build());
+            storage.create(
+                    BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, GeoParquetDatastoreCloudITSupport.OBJECT_NAME))
+                            .build(),
+                    java.nio.file.Files.readAllBytes(parquetFixture));
+        } finally {
+            try {
+                storage.close();
+            } catch (Exception e) {
+                throw new IOException("Failed to close GCS emulator client", e);
+            }
+        }
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryMinIOIT.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryMinIOIT.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Testcontainers(disabledWithoutDocker = true)
+class GeoParquetFileDataStoreFactoryMinIOIT {
+
+    private static final String BUCKET_NAME = "geoparquet-it";
+
+    @Container
+    static MinIOContainer minio = new MinIOContainer("minio/minio:latest");
+
+    private static URL minioFixtureUrl;
+
+    @BeforeAll
+    static void setupMinio(@TempDir Path tempDir) throws Exception {
+        Path parquetFixture =
+                GeoParquetDatastoreCloudITSupport.extractFixture(GeoParquetFileDataStoreFactoryMinIOIT.class, tempDir);
+        uploadFixture(parquetFixture);
+        minioFixtureUrl = new URL(
+                "%s/%s/%s".formatted(minio.getS3URL(), BUCKET_NAME, GeoParquetDatastoreCloudITSupport.OBJECT_NAME));
+    }
+
+    @Test
+    void createDataStore_requiresS3ConnectionParametersForMinioHttpUrl() {
+        assertThatThrownBy(
+                        () -> GeoParquetDatastoreCloudITSupport.FACTORY.createDataStore(Map.of("url", minioFixtureUrl)))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void createDataStore_readsParquetThroughParameterizedS3RangeReader() throws Exception {
+        Map<String, Object> params = Map.of(
+                "url",
+                minioFixtureUrl,
+                "io.tileverse.rangereader.provider",
+                "s3",
+                "io.tileverse.rangereader.s3.force-path-style",
+                true,
+                "io.tileverse.rangereader.s3.region",
+                "us-east-1",
+                "io.tileverse.rangereader.s3.aws-access-key-id",
+                minio.getUserName(),
+                "io.tileverse.rangereader.s3.aws-secret-access-key",
+                minio.getPassword());
+
+        GeoParquetDatastoreCloudITSupport.assertReadsSampleGeoParquet(params);
+    }
+
+    private static void uploadFixture(Path parquetFixture) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(minio.getUserName(), minio.getPassword());
+        try (S3Client client = S3Client.builder()
+                .endpointOverride(java.net.URI.create(minio.getS3URL()))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .forcePathStyle(true)
+                .build()) {
+            client.createBucket(
+                    CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+            client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(BUCKET_NAME)
+                            .key(GeoParquetDatastoreCloudITSupport.OBJECT_NAME)
+                            .build(),
+                    RequestBody.fromFile(parquetFixture));
+        }
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryTest.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetFileDataStoreFactoryTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Properties;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
@@ -67,7 +68,16 @@ class GeoParquetFileDataStoreFactoryTest {
     void factoryMetadataAndValidationMethods() throws Exception {
         assertThat(factory.isAvailable()).isTrue();
         assertThat(factory.getFileExtensions()).containsExactly(".parquet");
-        assertThat(factory.getParametersInfo()).hasSize(1);
+        assertThat(factory.getParametersInfo())
+                .extracting(p -> p.key)
+                .contains(
+                        "url",
+                        "io.tileverse.rangereader.provider",
+                        "io.tileverse.rangereader.caching.enabled",
+                        "io.tileverse.rangereader.http.timeout-millis",
+                        "io.tileverse.rangereader.azure.account-key",
+                        "io.tileverse.rangereader.s3.region",
+                        "io.tileverse.rangereader.gcs.project-id");
         assertThat(factory.getParametersInfo()[0].key).isEqualTo("url");
 
         assertThat(factory.canProcess((URL) null)).isFalse();
@@ -108,6 +118,30 @@ class GeoParquetFileDataStoreFactoryTest {
         assertThatThrownBy(() -> factory.createDataStore(Map.of("url", "not-a-url")))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("Invalid 'url' parameter");
+    }
+
+    @Test
+    void createDataStoreFromMap_acceptsRangeReaderConfiguration() throws Exception {
+        Path path = extractToTempFile(FIXTURE_RESOURCE);
+        Properties expected = new Properties();
+        expected.setProperty("io.tileverse.rangereader.caching.enabled", "true");
+        expected.setProperty("io.tileverse.rangereader.caching.blocksize", "4096");
+        Map<String, Object> params = Map.of(
+                "url",
+                path.toUri().toURL(),
+                "io.tileverse.rangereader.caching.enabled",
+                true,
+                "io.tileverse.rangereader.caching.blocksize",
+                4096);
+
+        assertThat(GeoParquetRangeReaderParams.toProperties(params)).isEqualTo(expected);
+
+        DataStore store = factory.createDataStore(params);
+        try {
+            assertThat(store.getTypeNames()).containsExactly("sample-geoparquet");
+        } finally {
+            store.dispose();
+        }
     }
 
     @Test

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetMetadataTest.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetMetadataTest.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
+
+class GeoParquetMetadataTest {
+
+    @Test
+    void readValue_supportsKnownAndUnknownVersions() throws Exception {
+        GeoParquetMetadata known = GeoParquetMetadata.readValue(
+                """
+                {
+                  "version": "1.2.0-dev",
+                  "primary_column": "geometry",
+                  "columns": {
+                    "geometry": {
+                      "encoding": "WKB",
+                      "geometry_types": ["Point"]
+                    }
+                  }
+                }
+                """);
+        assertThat(known).isInstanceOf(GeoParquetMetadata.V1_2_0Dev.class);
+        assertThat(known.getVersion()).isEqualTo("1.2.0-dev");
+
+        GeoParquetMetadata unknown = GeoParquetMetadata.readValue(
+                """
+                {
+                  "version": "9.9.9",
+                  "primary_column": "geometry",
+                  "columns": {
+                    "geometry": {
+                      "encoding": "WKB",
+                      "geometry_types": ["Point"]
+                    }
+                  }
+                }
+                """);
+        assertThat(unknown).isInstanceOf(GeoParquetMetadata.V1_1_0.class);
+        assertThat(unknown.getVersion()).isEqualTo("1.1.0");
+    }
+
+    @Test
+    void readValue_rejectsInvalidJson() {
+        assertThatThrownBy(() -> GeoParquetMetadata.readValue("{not-json")).isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void bounds_andGetColumnHandleMissingPrimaryColumnAndMissingColumns() {
+        GeoParquetMetadata.V1_1_0 metadata = new GeoParquetMetadata.V1_1_0();
+
+        assertThat(metadata.bounds()).isEqualTo(new Envelope());
+        assertThat(metadata.getColumn("geometry")).isEmpty();
+
+        metadata.setPrimaryColumn("geometry");
+        metadata.setColumns(Map.of());
+        assertThat(metadata.bounds()).isEqualTo(new Envelope());
+        assertThat(metadata.getColumn("geometry")).isEmpty();
+    }
+
+    @Test
+    void bounds_usesPrimaryColumnMetadataEnvelope() {
+        GeometryColumnMetadata geometry = new GeometryColumnMetadata();
+        geometry.setEncoding("WKB");
+        geometry.setGeometryTypes(List.of("Point"));
+        geometry.setBbox(List.of(-58.0, -34.0, -57.5, -33.5));
+
+        GeoParquetMetadata.V1_1_0 metadata = new GeoParquetMetadata.V1_1_0();
+        metadata.setPrimaryColumn("geometry");
+        metadata.setColumns(Map.of("geometry", geometry, "secondary", new GeometryColumnMetadata()));
+
+        assertThat(metadata.bounds()).isEqualTo(new Envelope(-58.0, -57.5, -34.0, -33.5));
+        assertThat(metadata.getColumn("geometry")).containsSame(geometry);
+        assertThat(metadata.getColumn("missing")).isEmpty();
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetRangeReaderParamsTest.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoParquetRangeReaderParamsTest.java
@@ -1,0 +1,109 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.geotools.parquet;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.geotools.api.data.DataAccessFactory.Param;
+import org.geotools.api.data.Parameter;
+import org.junit.jupiter.api.Test;
+
+class GeoParquetRangeReaderParamsTest {
+
+    @Test
+    void getParameters_returnsAllProviderBackedParamsInOrder() {
+        Param[] params = GeoParquetRangeReaderParams.getParameters();
+
+        assertThat(params).hasSize(GeoParquetRangeReaderParams.PARAMETERS.size());
+        assertThat(List.of(params))
+                .extracting(p -> p.key)
+                .containsExactlyElementsOf(GeoParquetRangeReaderParams.PARAMETERS.stream()
+                        .map(p -> p.key)
+                        .toList());
+    }
+
+    @Test
+    void factory_keepsUrlFirstAndAppendsGeoParquetRangeReaderParams() {
+        Param[] params = new GeoParquetFileDataStoreFactory().getParametersInfo();
+        List<String> expectedKeys = new java.util.ArrayList<>();
+        expectedKeys.add("url");
+        expectedKeys.addAll(List.of(GeoParquetRangeReaderParams.getParameters()).stream()
+                .map(p -> p.key)
+                .toList());
+
+        assertThat(params).extracting(p -> p.key).containsExactlyElementsOf(expectedKeys);
+    }
+
+    @Test
+    void providerParams_preserveRepresentativeMetadata() {
+        Param httpPassword = GeoParquetRangeReaderParams.HTTP_AUTH_PASSWORD;
+        Param providerId = GeoParquetRangeReaderParams.RANGEREADER_PROVIDER_ID;
+        Param gcsDefaultCredentials = GeoParquetRangeReaderParams.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS;
+
+        assertThat(httpPassword.type).isEqualTo(String.class);
+        assertThat(httpPassword.metadata).containsEntry(Parameter.IS_PASSWORD, Boolean.TRUE);
+        assertThat(httpPassword.metadata).containsEntry(Parameter.LEVEL, "http");
+
+        assertThat(providerId.type).isEqualTo(String.class);
+        assertThat(providerId.metadata).containsKey(Parameter.OPTIONS);
+        assertThat((Object[]) providerId.metadata.get(Parameter.OPTIONS))
+                .contains("file", "http", "s3", "azure", "gcs");
+
+        assertThat(gcsDefaultCredentials.type).isEqualTo(Boolean.class);
+        assertThat(gcsDefaultCredentials.sample).isEqualTo(false);
+        assertThat(gcsDefaultCredentials.metadata).containsEntry(Parameter.LEVEL, "gcs");
+    }
+
+    @Test
+    void toProperties_convertsSupportedParametersToStringValues() throws Exception {
+        URL url = new URL("file:/tmp/sample.parquet");
+        Map<String, Object> params = Map.ofEntries(
+                entry("url", url),
+                entry("unrelated", "ignored"),
+                entry("io.tileverse.rangereader.provider", "s3"),
+                entry("io.tileverse.rangereader.caching.enabled", true),
+                entry("io.tileverse.rangereader.caching.blockaligned", false),
+                entry("io.tileverse.rangereader.caching.blocksize", 8192),
+                entry("io.tileverse.rangereader.http.timeout-millis", 1500),
+                entry("io.tileverse.rangereader.http.username", "alice"),
+                entry("io.tileverse.rangereader.http.password", "secret"),
+                entry("io.tileverse.rangereader.s3.region", "us-east-1"),
+                entry("io.tileverse.rangereader.s3.force-path-style", true),
+                entry("io.tileverse.rangereader.gcs.project-id", "test-project"),
+                entry("io.tileverse.rangereader.gcs.default-credentials-chain", false));
+
+        Properties properties = GeoParquetRangeReaderParams.toProperties(params);
+
+        assertThat(properties)
+                .containsEntry("io.tileverse.rangereader.provider", "s3")
+                .containsEntry("io.tileverse.rangereader.caching.enabled", "true")
+                .containsEntry("io.tileverse.rangereader.caching.blockaligned", "false")
+                .containsEntry("io.tileverse.rangereader.caching.blocksize", "8192")
+                .containsEntry("io.tileverse.rangereader.http.timeout-millis", "1500")
+                .containsEntry("io.tileverse.rangereader.http.username", "alice")
+                .containsEntry("io.tileverse.rangereader.http.password", "secret")
+                .containsEntry("io.tileverse.rangereader.s3.region", "us-east-1")
+                .containsEntry("io.tileverse.rangereader.s3.force-path-style", "true")
+                .containsEntry("io.tileverse.rangereader.gcs.project-id", "test-project")
+                .containsEntry("io.tileverse.rangereader.gcs.default-credentials-chain", "false");
+        assertThat(properties).doesNotContainKeys("url", "unrelated");
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeometryColumnMetadataTest.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeometryColumnMetadataTest.java
@@ -1,0 +1,115 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
+
+class GeometryColumnMetadataTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void bounds_returnsEmptyEnvelopeWhenBboxIsMissingOrTooShort() {
+        GeometryColumnMetadata metadata = new GeometryColumnMetadata();
+        assertThat(metadata.bounds()).isEqualTo(new Envelope());
+
+        metadata.setBbox(List.of(1.0, 2.0, 3.0));
+        assertThat(metadata.bounds()).isEqualTo(new Envelope());
+    }
+
+    @Test
+    void bounds_usesTwoDimensionalAndThreeDimensionalBboxLayouts() {
+        GeometryColumnMetadata metadata = new GeometryColumnMetadata();
+        metadata.setBbox(List.of(-58.0, -34.0, -57.5, -33.5));
+
+        assertThat(metadata.bounds()).isEqualTo(new Envelope(-58.0, -57.5, -34.0, -33.5));
+
+        metadata.setBbox(List.of(-58.0, -34.0, 10.0, -57.5, -33.5, 30.0));
+        assertThat(metadata.bounds()).isEqualTo(new Envelope(-58.0, -57.5, -34.0, -33.5));
+    }
+
+    @Test
+    void accessors_roundTripAllMetadataFields() {
+        GeometryColumnMetadata.BboxCovering bboxCovering = new GeometryColumnMetadata.BboxCovering();
+        bboxCovering.setXmin(List.of("bbox", "xmin"));
+        bboxCovering.setXmax(List.of("bbox", "xmax"));
+        bboxCovering.setYmin(List.of("bbox", "ymin"));
+        bboxCovering.setYmax(List.of("bbox", "ymax"));
+        bboxCovering.setZmin(List.of("bbox", "zmin"));
+        bboxCovering.setZmax(List.of("bbox", "zmax"));
+
+        GeometryColumnMetadata.Covering covering = new GeometryColumnMetadata.Covering();
+        covering.setBbox(bboxCovering);
+
+        GeometryColumnMetadata metadata = new GeometryColumnMetadata();
+        metadata.setEncoding("WKB");
+        metadata.setGeometryTypes(List.of("Point", "MultiPoint"));
+        metadata.setEdges("planar");
+        metadata.setOrientation("counterclockwise");
+        metadata.setBbox(List.of(-58.0, -34.0, -57.5, -33.5));
+        metadata.setEpoch(2026.25);
+        metadata.setCovering(covering);
+
+        assertThat(metadata.getEncoding()).isEqualTo("WKB");
+        assertThat(metadata.getGeometryTypes()).containsExactly("Point", "MultiPoint");
+        assertThat(metadata.getEdges()).isEqualTo("planar");
+        assertThat(metadata.getOrientation()).isEqualTo("counterclockwise");
+        assertThat(metadata.getBbox()).containsExactly(-58.0, -34.0, -57.5, -33.5);
+        assertThat(metadata.getEpoch()).isEqualTo(2026.25);
+        assertThat(metadata.getCovering()).isSameAs(covering);
+        assertThat(metadata.getCovering().getBbox()).isSameAs(bboxCovering);
+        assertThat(metadata.getCovering().getBbox().getXmin()).containsExactly("bbox", "xmin");
+        assertThat(metadata.getCovering().getBbox().getXmax()).containsExactly("bbox", "xmax");
+        assertThat(metadata.getCovering().getBbox().getYmin()).containsExactly("bbox", "ymin");
+        assertThat(metadata.getCovering().getBbox().getYmax()).containsExactly("bbox", "ymax");
+        assertThat(metadata.getCovering().getBbox().getZmin()).containsExactly("bbox", "zmin");
+        assertThat(metadata.getCovering().getBbox().getZmax()).containsExactly("bbox", "zmax");
+    }
+
+    @Test
+    void deserialization_readsNestedCoveringStructure() throws Exception {
+        String json =
+                """
+                {
+                  "encoding": "WKB",
+                  "geometry_types": ["Polygon"],
+                  "bbox": [-58.0, -34.0, -57.5, -33.5],
+                  "covering": {
+                    "bbox": {
+                      "xmin": ["bbox", "xmin"],
+                      "xmax": ["bbox", "xmax"],
+                      "ymin": ["bbox", "ymin"],
+                      "ymax": ["bbox", "ymax"]
+                    }
+                  }
+                }
+                """;
+
+        GeometryColumnMetadata metadata = MAPPER.readValue(json, GeometryColumnMetadata.class);
+
+        assertThat(metadata.getEncoding()).isEqualTo("WKB");
+        assertThat(metadata.getGeometryTypes()).containsExactly("Polygon");
+        assertThat(metadata.bounds()).isEqualTo(new Envelope(-58.0, -57.5, -34.0, -33.5));
+        assertThat(metadata.getCovering()).isNotNull();
+        assertThat(metadata.getCovering().getBbox().getXmin()).containsExactly("bbox", "xmin");
+        assertThat(metadata.getCovering().getBbox().getYmax()).containsExactly("bbox", "ymax");
+    }
+}

--- a/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoparquetContentDataStoreTest.java
+++ b/tileverse-parquet-datastore/src/test/java/io/tileverse/geotools/parquet/GeoparquetContentDataStoreTest.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.geotools.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GeoparquetContentDataStoreTest {
+
+    private static final String FIXTURE_RESOURCE = "/geoparquet/sample-geoparquet.parquet";
+
+    @TempDir
+    Path tmpdir;
+
+    @Test
+    void parseGeoParquetMetadata_handlesMissingBlankInvalidAndValidValues() {
+        assertThat(GeoparquetContentDataStore.parseGeoParquetMetadata(Map.of())).isNull();
+        assertThat(GeoparquetContentDataStore.parseGeoParquetMetadata(Map.of("geo", "   ")))
+                .isNull();
+        assertThat(GeoparquetContentDataStore.parseGeoParquetMetadata(Map.of("geo", "{not-json")))
+                .isNull();
+
+        GeoParquetMetadata metadata = GeoparquetContentDataStore.parseGeoParquetMetadata(
+                Map.of(
+                        "geo",
+                        """
+                {
+                  "version": "1.1.0",
+                  "primary_column": "geometry",
+                  "columns": {
+                    "geometry": {
+                      "encoding": "WKB",
+                      "geometry_types": ["Point"]
+                    }
+                  }
+                }
+                """));
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getPrimaryColumn()).isEqualTo("geometry");
+    }
+
+    @Test
+    void extractGeometryColumnNames_handlesNullEmptyAndPresentMetadata() {
+        assertThat(GeoparquetContentDataStore.extractGeometryColumnNames(null)).isEmpty();
+
+        GeoParquetMetadata.V1_1_0 empty = new GeoParquetMetadata.V1_1_0();
+        empty.setColumns(Map.of());
+        assertThat(GeoparquetContentDataStore.extractGeometryColumnNames(empty)).isEmpty();
+
+        GeoParquetMetadata.V1_1_0 metadata = new GeoParquetMetadata.V1_1_0();
+        metadata.setColumns(
+                Map.of("geometry", new GeometryColumnMetadata(), "geometry2", new GeometryColumnMetadata()));
+        assertThat(GeoparquetContentDataStore.extractGeometryColumnNames(metadata))
+                .containsExactlyInAnyOrder("geometry", "geometry2");
+    }
+
+    @Test
+    void open_acceptsNullRangeReaderConfigAndBuildsStore() throws Exception {
+        GeoparquetContentDataStore store =
+                GeoparquetContentDataStore.open(fixtureUrl(), (Properties) null, TileverseParquetRecordSource::new);
+        try {
+            assertThat(store.getSchema().getTypeName()).isEqualTo("sample-geoparquet");
+            assertThat(store.getGeoParquetMetadata()).isNotNull();
+            assertThat(store.getWkbGeometryColumns()).containsExactly("geometry");
+        } finally {
+            store.dispose();
+        }
+    }
+
+    @Test
+    void open_closesReaderAndPropagatesFactoryFailures() throws Exception {
+        assertThatThrownBy(() -> GeoparquetContentDataStore.open(fixtureUrl(), new Properties(), rangeReader -> {
+                    throw new IOException("boom");
+                }))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
+
+        assertThatThrownBy(() -> GeoparquetContentDataStore.open(fixtureUrl(), new Properties(), rangeReader -> {
+                    throw new IllegalStateException("boom");
+                }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("boom");
+    }
+
+    private URL fixtureUrl() {
+        Path path = extractToTempFile(FIXTURE_RESOURCE);
+        try {
+            return path.toUri().toURL();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Path extractToTempFile(String resource) {
+        Path target = tmpdir.resolve(Path.of(resource).getFileName().toString());
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IOException("Missing fixture resource " + resource);
+            }
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+            return target;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/tileverse-parquet/src/test/java/io/tileverse/parquet/AvroMaterializerProviderTest.java
+++ b/tileverse-parquet/src/test/java/io/tileverse/parquet/AvroMaterializerProviderTest.java
@@ -257,4 +257,51 @@ class AvroMaterializerProviderTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported LIST field index");
     }
+
+    @Test
+    void arrayFieldConverter_collectsPrimitiveAndNestedRecordElements() {
+        Type primitiveRepeated = Types.primitive(PrimitiveTypeName.INT32, Type.Repetition.REPEATED)
+                .named("items");
+        Schema intArraySchema = Schema.createArray(Schema.create(Schema.Type.INT));
+        AtomicReference<Object> primitiveOut = new AtomicReference<>();
+        GroupConverter primitiveArray = new AvroMaterializerProvider.ArrayFieldConverter(
+                primitiveRepeated, intArraySchema, (AvroMaterializerProvider.ValueConsumer) primitiveOut::set);
+
+        primitiveArray.start();
+        ((PrimitiveConverter) primitiveArray.getConverter(0)).addInt(1);
+        ((PrimitiveConverter) primitiveArray.getConverter(0)).addInt(2);
+        primitiveArray.end();
+        assertThat(primitiveOut.get()).isEqualTo(List.of(1, 2));
+
+        GroupType structGroup = Types.buildGroup(Type.Repetition.OPTIONAL)
+                .required(PrimitiveTypeName.BINARY)
+                .as(LogicalTypeAnnotation.stringType())
+                .named("name")
+                .optional(PrimitiveTypeName.INT32)
+                .named("age")
+                .named("struct_items");
+        Schema recordSchema = Schema.createRecord("Item", null, null, false);
+        recordSchema.setFields(List.of(
+                new Schema.Field("name", Schema.create(Schema.Type.STRING), null, (Object) null),
+                new Schema.Field("age", Schema.create(Schema.Type.INT), null, (Object) null)));
+        Schema recordArraySchema = Schema.createArray(recordSchema);
+        AtomicReference<Object> recordOut = new AtomicReference<>();
+        GroupConverter recordArray = new AvroMaterializerProvider.ArrayFieldConverter(
+                structGroup, recordArraySchema, (AvroMaterializerProvider.ValueConsumer) recordOut::set);
+
+        recordArray.start();
+        GroupConverter element = (GroupConverter) recordArray.getConverter(0);
+        element.start();
+        ((PrimitiveConverter) element.getConverter(0)).addBinary(Binary.fromString("alice"));
+        ((PrimitiveConverter) element.getConverter(1)).addInt(33);
+        element.end();
+        recordArray.end();
+
+        assertThat(recordOut.get()).isInstanceOf(List.class);
+        assertThat((List<?>) recordOut.get()).hasSize(1);
+        assertThat(((GenericData.Record) ((List<?>) recordOut.get()).get(0))
+                        .get("name")
+                        .toString())
+                .isEqualTo("alice");
+    }
 }

--- a/tileverse-parquet/src/test/java/io/tileverse/parquet/reader/CompressionUtilTest.java
+++ b/tileverse-parquet/src/test/java/io/tileverse/parquet/reader/CompressionUtilTest.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ */
+package io.tileverse.parquet.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import org.apache.parquet.format.CompressionCodec;
+import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
+
+class CompressionUtilTest {
+
+    @Test
+    void decompress_supportsUncompressedSnappyGzipAndLz4Raw() throws Exception {
+        byte[] original = "tileverse-compression".getBytes(StandardCharsets.UTF_8);
+
+        assertThat(CompressionUtil.decompress(CompressionCodec.UNCOMPRESSED, original, original.length))
+                .isSameAs(original);
+
+        byte[] snappy = Snappy.compress(original);
+        assertThat(CompressionUtil.decompress(CompressionCodec.SNAPPY, snappy, original.length))
+                .isEqualTo(original);
+
+        byte[] gzip = gzip(original);
+        assertThat(CompressionUtil.decompress(CompressionCodec.GZIP, gzip, original.length))
+                .isEqualTo(original);
+
+        byte[] lz4raw = lz4Raw(original);
+        assertThat(CompressionUtil.decompress(CompressionCodec.LZ4_RAW, lz4raw, original.length))
+                .isEqualTo(original);
+    }
+
+    @Test
+    void decompress_supportsLegacyHadoopLz4Frames() throws Exception {
+        byte[] original = "tileverse-hadoop-lz4".getBytes(StandardCharsets.UTF_8);
+
+        byte[] framed = hadoopLz4Frame(original);
+
+        assertThat(CompressionUtil.decompress(CompressionCodec.LZ4, framed, original.length))
+                .isEqualTo(original);
+    }
+
+    @Test
+    void decompress_lz4HadoopRejectsHeaderAndOutputSizeMismatches() throws Exception {
+        byte[] original = "tileverse-hadoop-lz4".getBytes(StandardCharsets.UTF_8);
+        byte[] framed = hadoopLz4Frame(original);
+
+        ByteBuffer headerMismatch = ByteBuffer.wrap(framed.clone()).order(ByteOrder.BIG_ENDIAN);
+        headerMismatch.putInt(0, original.length + 1);
+
+        assertThatThrownBy(
+                        () -> CompressionUtil.decompress(CompressionCodec.LZ4, headerMismatch.array(), original.length))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("LZ4 Hadoop frame header declares");
+
+        ByteBuffer truncated = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+        truncated.putInt(original.length);
+        truncated.putInt(0);
+
+        assertThatThrownBy(() -> CompressionUtil.decompress(CompressionCodec.LZ4, truncated.array(), original.length))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("LZ4 Hadoop decompressed 0 bytes");
+    }
+
+    private static byte[] gzip(byte[] original) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(out)) {
+            gzip.write(original);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] lz4Raw(byte[] original) {
+        LZ4Compressor compressor = LZ4Factory.fastestInstance().fastCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(original.length)];
+        int size = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+        return java.util.Arrays.copyOf(compressed, size);
+    }
+
+    private static byte[] hadoopLz4Frame(byte[] original) {
+        byte[] compressed = lz4Raw(original);
+        ByteBuffer frame =
+                ByteBuffer.allocate(4 + 4 + 4 + compressed.length + 4).order(ByteOrder.BIG_ENDIAN);
+        frame.putInt(original.length);
+        frame.putInt(compressed.length);
+        frame.putInt(original.length);
+        frame.put(compressed);
+        frame.putInt(0);
+        return frame.array();
+    }
+}


### PR DESCRIPTION
Expose RangeReader cloud/auth parameters through the GeoParquet datastore and propagate them to RangeReaderFactory.