### PR TITLE
rangereader: migrate configuration keys to the storage.* namespace

### DIFF
--- a/tileverse-rangereader/all/src/test/java/io/tileverse/rangereader/spi/SpiKeyConventionTest.java
+++ b/tileverse-rangereader/all/src/test/java/io/tileverse/rangereader/spi/SpiKeyConventionTest.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.rangereader.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guard test: every {@link RangeReaderParameter} declared by any {@link RangeReaderProvider}
+ * on the classpath must use the canonical {@value RangeReaderConfig#KEY_PREFIX} prefix and must
+ * NOT use the legacy {@value RangeReaderConfig#LEGACY_KEY_PREFIX} prefix.
+ */
+class SpiKeyConventionTest {
+
+    @Test
+    void allProviderParameterKeysUseStoragePrefix() {
+        List<RangeReaderProvider> providers = RangeReaderProvider.getProviders();
+        assertThat(providers).as("expected SPI providers to be discovered").isNotEmpty();
+
+        for (RangeReaderProvider provider : providers) {
+            for (RangeReaderParameter<?> p : provider.getParameters()) {
+                assertThat(p.key())
+                        .as("%s parameter key must start with %s", provider.getId(), RangeReaderConfig.KEY_PREFIX)
+                        .startsWith(RangeReaderConfig.KEY_PREFIX);
+                assertThat(p.key())
+                        .as(
+                                "%s parameter key must not use the legacy %s prefix",
+                                provider.getId(), RangeReaderConfig.LEGACY_KEY_PREFIX)
+                        .doesNotStartWith(RangeReaderConfig.LEGACY_KEY_PREFIX);
+            }
+        }
+    }
+}

--- a/tileverse-rangereader/azure/src/main/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderProvider.java
+++ b/tileverse-rangereader/azure/src/main/java/io/tileverse/rangereader/azure/AzureBlobRangeReaderProvider.java
@@ -82,7 +82,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
      * @see BlobClientBuilder#blobName(String)
      */
     public static final RangeReaderParameter<String> AZURE_BLOB_NAME = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.azure.blob-name")
+            .key("storage.azure.blob-name")
             .title("Set the blob name if the endpoint points to the account url")
             .description(
                     """
@@ -104,7 +104,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
      * @see StorageSharedKeyCredential
      */
     public static final RangeReaderParameter<String> AZURE_ACCOUNT_KEY = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.azure.account-key")
+            .key("storage.azure.account-key")
             .title("Account access key")
             .description(
                     """
@@ -124,7 +124,7 @@ public class AzureBlobRangeReaderProvider extends AbstractRangeReaderProvider {
      * SAS token to use for authenticating requests
      */
     public static final RangeReaderParameter<String> AZURE_SAS_TOKEN = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.azure.sas-token")
+            .key("storage.azure.sas-token")
             .title("SAS token to use for authenticating requests")
             .description(
                     """

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/http/HttpRangeReaderProvider.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/http/HttpRangeReaderProvider.java
@@ -48,8 +48,8 @@ import java.util.Optional;
  *
  * <pre>{@code
  * Properties config = new Properties();
- * config.setProperty("io.tileverse.rangereader.http.username", "myuser");
- * config.setProperty("io.tileverse.rangereader.http.password", "mypassword");
+ * config.setProperty("storage.http.username", "myuser");
+ * config.setProperty("storage.http.password", "mypassword");
  * RangeReader reader = RangeReaderFactory.create(uri, config);
  * }</pre>
  *
@@ -59,7 +59,7 @@ import java.util.Optional;
  *
  * <pre>{@code
  * Properties config = new Properties();
- * config.setProperty("io.tileverse.rangereader.http.bearer-token", "eyJhbGciOi...");
+ * config.setProperty("storage.http.bearer-token", "eyJhbGciOi...");
  * RangeReader reader = RangeReaderFactory.create(uri, config);
  * }</pre>
  *
@@ -70,8 +70,8 @@ import java.util.Optional;
  *
  * <pre>{@code
  * Properties config = new Properties();
- * config.setProperty("io.tileverse.rangereader.http.api-key-headername", "X-API-Key");
- * config.setProperty("io.tileverse.rangereader.http.api-key", "abc123xyz");
+ * config.setProperty("storage.http.api-key-headername", "X-API-Key");
+ * config.setProperty("storage.http.api-key", "abc123xyz");
  * RangeReader reader = RangeReaderFactory.create(uri, config);
  * }</pre>
  *
@@ -90,7 +90,7 @@ import java.util.Optional;
  * recognized as cloud provider endpoints (S3, Azure, GCS). For ambiguous cases,
  * this provider can be explicitly selected using:
  * <pre>{@code
- * config.setProperty("io.tileverse.rangereader.provider", "http");
+ * config.setProperty("storage.provider", "http");
  * }</pre>
  *
  * @see HttpRangeReader
@@ -114,10 +114,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * HTTP connection timeout in milliseconds.
      * <p>Specifies the maximum time to wait when establishing a connection to the HTTP server.
      * Default is 5000ms (5 seconds).
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.timeout-millis}
+     * <p><b>Key:</b> {@code storage.http.timeout-millis}
      */
     public static final RangeReaderParameter<Integer> HTTP_CONNECTION_TIMEOUT_MILLIS = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.timeout-millis")
+            .key("storage.http.timeout-millis")
             .title("HTTP connection timeout in milliseconds")
             .description(
                     """
@@ -133,10 +133,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * Trust all SSL/TLS certificates, including self-signed certificates.
      * <p><b>WARNING:</b> This disables certificate validation and should only be used in
      * development/testing environments. In production, use properly signed certificates.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.trust-all-certificates}
+     * <p><b>Key:</b> {@code storage.http.trust-all-certificates}
      */
     public static final RangeReaderParameter<Boolean> HTTP_TRUST_ALL_SSL_CERTIFICATES = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.trust-all-certificates")
+            .key("storage.http.trust-all-certificates")
             .title("Trust all SSL/TLS certificates")
             .description(
                     """
@@ -153,10 +153,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * <p>Used in combination with {@link #HTTP_AUTH_PASSWORD} to authenticate with servers
      * that require HTTP Basic Authentication. The credentials are sent with each request
      * using the {@code Authorization: Basic} header.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.username}
+     * <p><b>Key:</b> {@code storage.http.username}
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_USERNAME = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.username")
+            .key("storage.http.username")
             .title("HTTP Basic Auth username")
             .description(
                     """
@@ -172,10 +172,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * <p>Used in combination with {@link #HTTP_AUTH_USERNAME} to authenticate with servers
      * that require HTTP Basic Authentication. The credentials are sent with each request
      * using the {@code Authorization: Basic} header.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.password}
+     * <p><b>Key:</b> {@code storage.http.password}
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_PASSWORD = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.password")
+            .key("storage.http.password")
             .title("HTTP Basic Auth password")
             .description(
                     """
@@ -192,10 +192,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * <p>Provides a bearer token that will be sent with each request using the
      * {@code Authorization: Bearer <token>} header. Commonly used for OAuth 2.0 and JWT-based
      * authentication schemes.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.bearer-token}
+     * <p><b>Key:</b> {@code storage.http.bearer-token}
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_BEARER_TOKEN = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.bearer-token")
+            .key("storage.http.bearer-token")
             .title("HTTP Bearer Token")
             .description(
                     """
@@ -215,10 +215,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * <p>Specifies the HTTP header name to use for API key authentication. Common values include
      * {@code X-API-Key}, {@code Authorization}, {@code api-key}, etc. Must be used together with
      * {@link #HTTP_AUTH_API_KEY}.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.api-key-headername}
+     * <p><b>Key:</b> {@code storage.http.api-key-headername}
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_API_KEY_HEADERNAME = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.api-key-headername")
+            .key("storage.http.api-key-headername")
             .title("API-Key header name")
             .description(
                     """
@@ -236,10 +236,10 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * API key value for custom header authentication.
      * <p>The actual API key to send in the custom header specified by {@link #HTTP_AUTH_API_KEY_HEADERNAME}.
      * Optionally, a prefix can be specified using {@link #HTTP_AUTH_API_KEY_VALUE_PREFIX}.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.api-key}
+     * <p><b>Key:</b> {@code storage.http.api-key}
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_API_KEY = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.api-key")
+            .key("storage.http.api-key")
             .title("API key value")
             .description(
                     """
@@ -258,12 +258,12 @@ public class HttpRangeReaderProvider extends AbstractRangeReaderProvider {
      * <p>Some APIs require a prefix before the API key value (e.g., {@code ApiKey }, {@code Token }).
      * This parameter specifies that prefix, which will be prepended to the {@link #HTTP_AUTH_API_KEY}
      * value before sending.
-     * <p><b>Key:</b> {@code io.tileverse.rangereader.http.api-key-value-prefix}
+     * <p><b>Key:</b> {@code storage.http.api-key-value-prefix}
      * <p><b>Example:</b> If prefix is {@code "ApiKey "} and key is {@code "abc123"}, the header
      * value will be {@code "ApiKey abc123"}.
      */
     public static final RangeReaderParameter<String> HTTP_AUTH_API_KEY_VALUE_PREFIX = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.http.api-key-value-prefix")
+            .key("storage.http.api-key-value-prefix")
             .title("API key value prefix")
             .description(
                     """

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/CachingProviderHelper.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/CachingProviderHelper.java
@@ -35,7 +35,7 @@ class CachingProviderHelper {
      * When enabled, a {@link CachingRangeReader} will wrap the underlying {@link RangeReader}.
      */
     static final RangeReaderParameter<Boolean> MEMORY_CACHE_ENABLED = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.caching.enabled")
+            .key("storage.caching.enabled")
             .title("Enable memory cache for raw byte data")
             .description(
                     """
@@ -58,7 +58,7 @@ class CachingProviderHelper {
      * Block alignment can improve performance for certain storage types by optimizing read patterns.
      */
     static final RangeReaderParameter<Boolean> MEMORY_CACHE_BLOCK_ALIGNED = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.caching.blockaligned")
+            .key("storage.caching.blockaligned")
             .title("Apply block alignment for cached byte ranges")
             .description(
                     """
@@ -83,7 +83,7 @@ class CachingProviderHelper {
      * The block size should be a power of 2 for optimal performance.
      */
     static final RangeReaderParameter<Integer> MEMORY_CACHE_BLOCK_SIZE = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.caching.blocksize")
+            .key("storage.caching.blocksize")
             .title("Cache block size in bytes (power of 2)")
             .description(
                     """

--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/RangeReaderConfig.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/RangeReaderConfig.java
@@ -23,10 +23,15 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents the configuration for creating a {@link io.tileverse.rangereader.RangeReader} instance.
@@ -35,16 +40,37 @@ import java.util.Properties;
  */
 public class RangeReaderConfig {
 
-    /**
-     * The key used in {@link Properties} to specify the URI of the resource.
-     */
-    public static final String URI_KEY = "io.tileverse.rangereader.uri";
+    private static final Logger log = LoggerFactory.getLogger(RangeReaderConfig.class);
 
     /**
-     * The key used in {@link Properties} to specify the ID of a {@link RangeReaderProvider}.
+     * Prefix used on all canonical parameter keys going forward (e.g. {@code storage.s3.region}).
+     */
+    public static final String KEY_PREFIX = "storage.";
+
+    /**
+     * Prefix used by legacy (pre-{@code storage.*}) parameter keys. Legacy keys remain accepted
+     * on input for backwards compatibility with existing GeoServer catalogs.
+     */
+    public static final String LEGACY_KEY_PREFIX = "io.tileverse.rangereader.";
+
+    private static final Set<String> warnedLegacyKeys = ConcurrentHashMap.newKeySet();
+
+    /**
+     * The canonical key used in {@link Properties} to specify the URI of the resource.
+     */
+    public static final String URI_KEY = KEY_PREFIX + "uri";
+
+    /**
+     * The canonical key used in {@link Properties} to specify the ID of a {@link RangeReaderProvider}.
      * This can be used to force the use of a specific provider when URI-based disambiguation is not sufficient.
      */
-    public static final String PROVIDER_ID_KEY = "io.tileverse.rangereader.provider";
+    public static final String PROVIDER_ID_KEY = KEY_PREFIX + "provider";
+
+    /** Legacy URI key, still accepted as input for backwards compatibility. */
+    static final String LEGACY_URI_KEY = LEGACY_KEY_PREFIX + "uri";
+
+    /** Legacy provider-id key, still accepted as input for backwards compatibility. */
+    static final String LEGACY_PROVIDER_ID_KEY = LEGACY_KEY_PREFIX + "provider";
 
     /**
      * A parameter that can be used by client code to force a given {@link #providerId(String) provider id}
@@ -146,10 +172,11 @@ public class RangeReaderConfig {
      * @return This {@code RangeReaderConfig} instance for method chaining.
      */
     public RangeReaderConfig setParameter(String key, Object value) {
-        if (FORCE_PROVIDER_ID.key().equals(key)) {
+        String normalized = normalizeKey(requireNonNull(key, "key"));
+        if (FORCE_PROVIDER_ID.key().equals(normalized)) {
             this.providerId = value == null ? null : String.valueOf(value);
         }
-        this.parameterValues.put(requireNonNull(key, "key"), value);
+        this.parameterValues.put(normalized, value);
         return this;
     }
 
@@ -203,8 +230,9 @@ public class RangeReaderConfig {
      * @throws IllegalArgumentException if the value cannot be converted to the specified type.
      */
     public <T> Optional<T> getParameter(String key, Class<T> type) {
-        Object value = parameterValues.get(requireNonNull(key, "key"));
+        String normalized = normalizeKey(requireNonNull(key, "key"));
         requireNonNull(type, "type");
+        Object value = parameterValues.get(normalized);
         if (value == null) {
             return Optional.empty();
         }
@@ -275,10 +303,17 @@ public class RangeReaderConfig {
      */
     public static RangeReaderConfig fromProperties(Properties properties) {
         requireNonNull(properties);
-        Object urip = requireNonNull(properties.get(URI_KEY), "Properties must include " + URI_KEY);
+        Object urip = properties.get(URI_KEY);
+        if (urip == null) {
+            urip = properties.get(LEGACY_URI_KEY);
+        }
+        requireNonNull(urip, "Properties must include " + URI_KEY);
 
         URI uri = convertToURI(urip);
-        String providerId = properties.getProperty(FORCE_PROVIDER_ID.key());
+        String providerId = properties.getProperty(PROVIDER_ID_KEY);
+        if (providerId == null) {
+            providerId = properties.getProperty(LEGACY_PROVIDER_ID_KEY);
+        }
 
         RangeReaderConfig config = new RangeReaderConfig().uri(uri);
         config.providerId(providerId);
@@ -286,7 +321,9 @@ public class RangeReaderConfig {
         Properties copy = new Properties();
         copy.putAll(properties);
         copy.remove(URI_KEY);
+        copy.remove(LEGACY_URI_KEY);
         copy.remove(PROVIDER_ID_KEY);
+        copy.remove(LEGACY_PROVIDER_ID_KEY);
         copy.forEach((k, v) -> config.setParameter(String.valueOf(k), v));
         return config;
     }
@@ -341,6 +378,42 @@ public class RangeReaderConfig {
             }
             throw new IllegalArgumentException("Invalid URI: " + uriString, e);
         }
+    }
+
+    /**
+     * Normalizes a parameter key by rewriting the legacy {@value #LEGACY_KEY_PREFIX} prefix to
+     * the canonical {@value #KEY_PREFIX} prefix. Logs a one-time WARN per distinct legacy key.
+     *
+     * @param key The parameter key, possibly {@code null}.
+     * @return The normalized key, or {@code key} unchanged if it does not use the legacy prefix.
+     */
+    public static String normalizeKey(String key) {
+        if (key != null && key.startsWith(LEGACY_KEY_PREFIX)) {
+            String normalized = KEY_PREFIX + key.substring(LEGACY_KEY_PREFIX.length());
+            if (warnedLegacyKeys.add(key)) {
+                log.warn(
+                        "Legacy parameter key '{}' — use '{}'. Legacy keys remain accepted for backwards compatibility; new configurations should use the '{}*' form.",
+                        key,
+                        normalized,
+                        KEY_PREFIX);
+            }
+            return normalized;
+        }
+        return key;
+    }
+
+    /**
+     * Returns a copy of the given map with every key normalized via {@link #normalizeKey(String)}.
+     * Iteration order is preserved.
+     *
+     * @param in source map, must not be {@code null}.
+     * @return a new {@link LinkedHashMap} with normalized keys.
+     */
+    public static Map<String, Object> normalizeKeys(Map<String, ?> in) {
+        requireNonNull(in, "in");
+        Map<String, Object> out = new LinkedHashMap<>(in.size());
+        in.forEach((k, v) -> out.put(normalizeKey(k), v));
+        return out;
     }
 
     /**

--- a/tileverse-rangereader/core/src/test/java/io/tileverse/rangereader/spi/RangeReaderConfigTest.java
+++ b/tileverse-rangereader/core/src/test/java/io/tileverse/rangereader/spi/RangeReaderConfigTest.java
@@ -1,0 +1,129 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.rangereader.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class RangeReaderConfigTest {
+
+    @Test
+    void normalizeKey_canonicalPrefix_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey("storage.s3.region")).isEqualTo("storage.s3.region");
+        assertThat(RangeReaderConfig.normalizeKey("storage.uri")).isEqualTo("storage.uri");
+    }
+
+    @Test
+    void normalizeKey_legacyPrefix_rewritten() {
+        assertThat(RangeReaderConfig.normalizeKey("io.tileverse.rangereader.s3.region"))
+                .isEqualTo("storage.s3.region");
+        assertThat(RangeReaderConfig.normalizeKey("io.tileverse.rangereader.uri"))
+                .isEqualTo("storage.uri");
+        assertThat(RangeReaderConfig.normalizeKey("io.tileverse.rangereader.provider"))
+                .isEqualTo("storage.provider");
+    }
+
+    @Test
+    void normalizeKey_unrelated_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey("pmtiles")).isEqualTo("pmtiles");
+        assertThat(RangeReaderConfig.normalizeKey("namespace")).isEqualTo("namespace");
+    }
+
+    @Test
+    void normalizeKey_null_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey(null)).isNull();
+    }
+
+    @Test
+    void normalizeKeys_mapRewrite_preservesValues() {
+        Map<String, Object> in = Map.of(
+                "io.tileverse.rangereader.s3.region", "us-west-2",
+                "storage.azure.blob-name", "foo.pmtiles",
+                "pmtiles", "file:///tmp/x.pmtiles");
+        Map<String, Object> out = RangeReaderConfig.normalizeKeys(in);
+        assertThat(out).containsOnlyKeys("storage.s3.region", "storage.azure.blob-name", "pmtiles");
+        assertThat(out).containsEntry("storage.s3.region", "us-west-2");
+        assertThat(out).containsEntry("storage.azure.blob-name", "foo.pmtiles");
+        assertThat(out).containsEntry("pmtiles", "file:///tmp/x.pmtiles");
+    }
+
+    @Test
+    void setParameter_legacyKey_readableAsCanonical() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("io.tileverse.rangereader.s3.region", "eu-west-1");
+        assertThat(config.getParameter("storage.s3.region", String.class)).contains("eu-west-1");
+    }
+
+    @Test
+    void setParameter_canonicalKey_readableAsLegacy() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("storage.azure.blob-name", "foo.pmtiles");
+        assertThat(config.getParameter("io.tileverse.rangereader.azure.blob-name", String.class))
+                .contains("foo.pmtiles");
+    }
+
+    @Test
+    void setParameter_legacyProviderKey_populatesProviderId() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("io.tileverse.rangereader.provider", "s3");
+        assertThat(config.providerId()).contains("s3");
+    }
+
+    @Test
+    void fromProperties_legacyUriAndProviderKeys_parseCorrectly() {
+        Properties p = new Properties();
+        p.setProperty("io.tileverse.rangereader.uri", "file:///tmp/x.pmtiles");
+        p.setProperty("io.tileverse.rangereader.provider", "s3");
+        p.setProperty("io.tileverse.rangereader.s3.region", "us-west-2");
+
+        RangeReaderConfig config = RangeReaderConfig.fromProperties(p);
+
+        assertThat(config.uri().toString()).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(config.providerId()).contains("s3");
+        assertThat(config.getParameter("storage.s3.region", String.class)).contains("us-west-2");
+    }
+
+    @Test
+    void fromProperties_canonicalUriAndProviderKeys_parseCorrectly() {
+        Properties p = new Properties();
+        p.setProperty("storage.uri", "file:///tmp/x.pmtiles");
+        p.setProperty("storage.provider", "s3");
+        p.setProperty("storage.s3.region", "us-west-2");
+
+        RangeReaderConfig config = RangeReaderConfig.fromProperties(p);
+
+        assertThat(config.uri().toString()).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(config.providerId()).contains("s3");
+        assertThat(config.getParameter("storage.s3.region", String.class)).contains("us-west-2");
+    }
+
+    @Test
+    void toProperties_emitsOnlyCanonicalKeys() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("io.tileverse.rangereader.s3.region", "us-west-2");
+        config.providerId("s3");
+
+        Properties out = config.toProperties();
+
+        assertThat(out.stringPropertyNames()).allMatch(k -> !k.startsWith("io.tileverse.rangereader."));
+        assertThat(out.getProperty("storage.uri")).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(out.getProperty("storage.provider")).isEqualTo("s3");
+        assertThat(out.getProperty("storage.s3.region")).isEqualTo("us-west-2");
+    }
+}

--- a/tileverse-rangereader/gcs/src/main/java/io/tileverse/rangereader/gcs/GoogleCloudStorageRangeReaderProvider.java
+++ b/tileverse-rangereader/gcs/src/main/java/io/tileverse/rangereader/gcs/GoogleCloudStorageRangeReaderProvider.java
@@ -83,7 +83,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
      * Project ID is a unique, user-defined identifier for a Google Cloud project.
      */
     public static final RangeReaderParameter<String> GCS_PROJECT_ID = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.gcs.project-id")
+            .key("storage.gcs.project-id")
             .title("Google Cloud project ID")
             .description(
                     """
@@ -108,7 +108,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
      * Quota ProjectId that specifies the project used for quota and billing purposes.
      */
     public static final RangeReaderParameter<String> GCS_QUOTA_PROJECT_ID = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.gcs.quota-project-id")
+            .key("storage.gcs.quota-project-id")
             .title("Quota Project ID")
             .description(
                     """
@@ -125,7 +125,7 @@ public class GoogleCloudStorageRangeReaderProvider extends AbstractRangeReaderPr
      */
     public static final RangeReaderParameter<Boolean> GCS_USE_DEFAULT_APPLICTION_CREDENTIALS =
             RangeReaderParameter.builder()
-                    .key("io.tileverse.rangereader.gcs.default-credentials-chain")
+                    .key("storage.gcs.default-credentials-chain")
                     .title("Use the default application credentials chain")
                     .description(
                             """

--- a/tileverse-rangereader/s3/src/main/java/io/tileverse/rangereader/s3/S3RangeReaderProvider.java
+++ b/tileverse-rangereader/s3/src/main/java/io/tileverse/rangereader/s3/S3RangeReaderProvider.java
@@ -94,7 +94,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
      * compatibility with S3-compatible storage systems that do not support virtual-hosted-style requests.
      */
     public static final RangeReaderParameter<Boolean> S3_FORCE_PATH_STYLE = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.force-path-style")
+            .key("storage.s3.force-path-style")
             .title("Enable S3 path style access")
             .description(
                     """
@@ -117,7 +117,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
 
     /** Configuration parameter for AWS S3 region. */
     public static final RangeReaderParameter<String> S3_REGION = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.region")
+            .key("storage.s3.region")
             .title("Region")
             .description(
                     """
@@ -150,7 +150,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
      * The AWS access key ID to use for authentication when both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are provided.
      */
     public static final RangeReaderParameter<String> S3_AWS_ACCESS_KEY_ID = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.aws-access-key-id")
+            .key("storage.s3.aws-access-key-id")
             .title("AWS Access Key ID")
             .description(
                     """
@@ -171,7 +171,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
      * The AWS secret access key to use for authentication when both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are provided.
      */
     public static final RangeReaderParameter<String> S3_AWS_SECRET_ACCESS_KEY = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.aws-secret-access-key")
+            .key("storage.s3.aws-secret-access-key")
             .title("AWS Secret Access Key")
             .description(
                     """
@@ -192,7 +192,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
     /** Configuration parameter to control whether to use the default AWS credentials provider chain. */
     public static final RangeReaderParameter<Boolean> S3_USE_DEFAULT_CREDENTIALS_PROVIDER =
             RangeReaderParameter.builder()
-                    .key("io.tileverse.rangereader.s3.use-default-credentials-provider")
+                    .key("storage.s3.use-default-credentials-provider")
                     .title("Use Default Credentials Provider")
                     .description(
                             """
@@ -215,7 +215,7 @@ public class S3RangeReaderProvider extends AbstractRangeReaderProvider {
 
     /** Configuration parameter to specify a custom AWS credentials profile name. */
     public static final RangeReaderParameter<String> S3_DEFAULT_CREDENTIALS_PROFILE = RangeReaderParameter.builder()
-            .key("io.tileverse.rangereader.s3.default-credentials-profile")
+            .key("storage.s3.default-credentials-profile")
             .title("Default Credentials Profile")
             .description(
                     """


### PR DESCRIPTION
Renames every `RangeReaderParameter` key from `io.tileverse.rangereader.<group>.<name>` to `storage.<group>.<name>` (e.g. `io.tileverse.rangereader.s3.region` -> `storage.s3.region`, `io.tileverse.rangereader.uri` -> `storage.uri`). 

Legacy keys remain accepted on input for backwards compatibility with existing GeoServer catalog XML, no migration step needed on the persistence side.
