### PR TITLE
rangereader: accept 1.4-style storage.* parameter keys for forward compatibility

### DIFF
--- a/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/RangeReaderConfig.java
+++ b/tileverse-rangereader/core/src/main/java/io/tileverse/rangereader/spi/RangeReaderConfig.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,15 +37,36 @@ import java.util.Properties;
 public class RangeReaderConfig {
 
     /**
-     * The key used in {@link Properties} to specify the URI of the resource.
+     * Canonical prefix for parameter keys in the 1.3.x series (e.g.
+     * {@code io.tileverse.rangereader.s3.region}).
      */
-    public static final String URI_KEY = "io.tileverse.rangereader.uri";
+    public static final String KEY_PREFIX = "io.tileverse.rangereader.";
 
     /**
-     * The key used in {@link Properties} to specify the ID of a {@link RangeReaderProvider}.
+     * Forward-compatibility prefix: parameter keys shaped as {@code storage.<group>.<name>}
+     * are introduced in the 1.4.x series. 1.3.x accepts them on input so a data directory
+     * written by a 1.4 range reader (e.g. a catalog touched by GeoServer 3.1) can still be
+     * read by a 1.3 range reader (e.g. GeoServer 3.0). Keys are silently rewritten to the
+     * {@link #KEY_PREFIX canonical} form on the way in.
+     */
+    public static final String STORAGE_KEY_PREFIX = "storage.";
+
+    /**
+     * The canonical key used in {@link Properties} to specify the URI of the resource.
+     */
+    public static final String URI_KEY = KEY_PREFIX + "uri";
+
+    /**
+     * The canonical key used in {@link Properties} to specify the ID of a {@link RangeReaderProvider}.
      * This can be used to force the use of a specific provider when URI-based disambiguation is not sufficient.
      */
-    public static final String PROVIDER_ID_KEY = "io.tileverse.rangereader.provider";
+    public static final String PROVIDER_ID_KEY = KEY_PREFIX + "provider";
+
+    /** Forward-compat URI key (1.4.x form), still accepted as input for data-directory interop. */
+    static final String STORAGE_URI_KEY = STORAGE_KEY_PREFIX + "uri";
+
+    /** Forward-compat provider-id key (1.4.x form), still accepted as input for data-directory interop. */
+    static final String STORAGE_PROVIDER_ID_KEY = STORAGE_KEY_PREFIX + "provider";
 
     /**
      * A parameter that can be used by client code to force a given {@link #providerId(String) provider id}
@@ -146,10 +168,11 @@ public class RangeReaderConfig {
      * @return This {@code RangeReaderConfig} instance for method chaining.
      */
     public RangeReaderConfig setParameter(String key, Object value) {
-        if (FORCE_PROVIDER_ID.key().equals(key)) {
+        String normalized = normalizeKey(requireNonNull(key, "key"));
+        if (FORCE_PROVIDER_ID.key().equals(normalized)) {
             this.providerId = value == null ? null : String.valueOf(value);
         }
-        this.parameterValues.put(requireNonNull(key, "key"), value);
+        this.parameterValues.put(normalized, value);
         return this;
     }
 
@@ -203,8 +226,9 @@ public class RangeReaderConfig {
      * @throws IllegalArgumentException if the value cannot be converted to the specified type.
      */
     public <T> Optional<T> getParameter(String key, Class<T> type) {
-        Object value = parameterValues.get(requireNonNull(key, "key"));
+        String normalized = normalizeKey(requireNonNull(key, "key"));
         requireNonNull(type, "type");
+        Object value = parameterValues.get(normalized);
         if (value == null) {
             return Optional.empty();
         }
@@ -275,10 +299,17 @@ public class RangeReaderConfig {
      */
     public static RangeReaderConfig fromProperties(Properties properties) {
         requireNonNull(properties);
-        Object urip = requireNonNull(properties.get(URI_KEY), "Properties must include " + URI_KEY);
+        Object urip = properties.get(URI_KEY);
+        if (urip == null) {
+            urip = properties.get(STORAGE_URI_KEY);
+        }
+        requireNonNull(urip, "Properties must include " + URI_KEY);
 
         URI uri = convertToURI(urip);
-        String providerId = properties.getProperty(FORCE_PROVIDER_ID.key());
+        String providerId = properties.getProperty(PROVIDER_ID_KEY);
+        if (providerId == null) {
+            providerId = properties.getProperty(STORAGE_PROVIDER_ID_KEY);
+        }
 
         RangeReaderConfig config = new RangeReaderConfig().uri(uri);
         config.providerId(providerId);
@@ -286,9 +317,39 @@ public class RangeReaderConfig {
         Properties copy = new Properties();
         copy.putAll(properties);
         copy.remove(URI_KEY);
+        copy.remove(STORAGE_URI_KEY);
         copy.remove(PROVIDER_ID_KEY);
+        copy.remove(STORAGE_PROVIDER_ID_KEY);
         copy.forEach((k, v) -> config.setParameter(String.valueOf(k), v));
         return config;
+    }
+
+    /**
+     * Normalizes a parameter key by rewriting the forward-compat {@value #STORAGE_KEY_PREFIX}
+     * prefix (introduced in the 1.4 series) to the 1.3.x canonical {@value #KEY_PREFIX} prefix.
+     *
+     * @param key the parameter key, possibly {@code null}.
+     * @return the normalized key, or {@code key} unchanged if it does not use the forward-compat prefix.
+     */
+    public static String normalizeKey(String key) {
+        if (key != null && key.startsWith(STORAGE_KEY_PREFIX)) {
+            return KEY_PREFIX + key.substring(STORAGE_KEY_PREFIX.length());
+        }
+        return key;
+    }
+
+    /**
+     * Returns a copy of the given map with every key passed through {@link #normalizeKey(String)}.
+     * Iteration order is preserved.
+     *
+     * @param in source map, must not be {@code null}.
+     * @return a new {@link LinkedHashMap} with normalized keys.
+     */
+    public static Map<String, Object> normalizeKeys(Map<String, ?> in) {
+        requireNonNull(in, "in");
+        Map<String, Object> out = new LinkedHashMap<>(in.size());
+        in.forEach((k, v) -> out.put(normalizeKey(k), v));
+        return out;
     }
 
     /**

--- a/tileverse-rangereader/core/src/test/java/io/tileverse/rangereader/spi/RangeReaderConfigTest.java
+++ b/tileverse-rangereader/core/src/test/java/io/tileverse/rangereader/spi/RangeReaderConfigTest.java
@@ -1,0 +1,137 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.rangereader.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Forward-compatibility tests: the 1.3.x series must accept configuration keys written by the
+ * 1.4 series (shaped as {@code storage.<group>.<name>}) so that data directories remain
+ * interoperable in either direction.
+ */
+class RangeReaderConfigTest {
+
+    @Test
+    void normalizeKey_canonicalPrefix_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey("io.tileverse.rangereader.s3.region"))
+                .isEqualTo("io.tileverse.rangereader.s3.region");
+        assertThat(RangeReaderConfig.normalizeKey("io.tileverse.rangereader.uri"))
+                .isEqualTo("io.tileverse.rangereader.uri");
+    }
+
+    @Test
+    void normalizeKey_storagePrefix_rewrittenToCanonical() {
+        assertThat(RangeReaderConfig.normalizeKey("storage.s3.region")).isEqualTo("io.tileverse.rangereader.s3.region");
+        assertThat(RangeReaderConfig.normalizeKey("storage.uri")).isEqualTo("io.tileverse.rangereader.uri");
+        assertThat(RangeReaderConfig.normalizeKey("storage.provider")).isEqualTo("io.tileverse.rangereader.provider");
+    }
+
+    @Test
+    void normalizeKey_unrelated_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey("pmtiles")).isEqualTo("pmtiles");
+        assertThat(RangeReaderConfig.normalizeKey("namespace")).isEqualTo("namespace");
+    }
+
+    @Test
+    void normalizeKey_null_passthrough() {
+        assertThat(RangeReaderConfig.normalizeKey(null)).isNull();
+    }
+
+    @Test
+    void normalizeKeys_mapRewrite_preservesValues() {
+        Map<String, Object> in = Map.of(
+                "storage.s3.region", "us-west-2",
+                "io.tileverse.rangereader.azure.blob-name", "foo.pmtiles",
+                "pmtiles", "file:///tmp/x.pmtiles");
+        Map<String, Object> out = RangeReaderConfig.normalizeKeys(in);
+        assertThat(out)
+                .containsOnlyKeys(
+                        "io.tileverse.rangereader.s3.region", "io.tileverse.rangereader.azure.blob-name", "pmtiles");
+        assertThat(out).containsEntry("io.tileverse.rangereader.s3.region", "us-west-2");
+        assertThat(out).containsEntry("io.tileverse.rangereader.azure.blob-name", "foo.pmtiles");
+        assertThat(out).containsEntry("pmtiles", "file:///tmp/x.pmtiles");
+    }
+
+    @Test
+    void setParameter_storageKey_readableAsCanonical() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("storage.s3.region", "eu-west-1");
+        assertThat(config.getParameter("io.tileverse.rangereader.s3.region", String.class))
+                .contains("eu-west-1");
+    }
+
+    @Test
+    void setParameter_canonicalKey_readableAsStorage() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("io.tileverse.rangereader.azure.blob-name", "foo.pmtiles");
+        assertThat(config.getParameter("storage.azure.blob-name", String.class)).contains("foo.pmtiles");
+    }
+
+    @Test
+    void setParameter_storageProviderKey_populatesProviderId() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("storage.provider", "s3");
+        assertThat(config.providerId()).contains("s3");
+    }
+
+    @Test
+    void fromProperties_storageUriAndProviderKeys_parseCorrectly() {
+        Properties p = new Properties();
+        p.setProperty("storage.uri", "file:///tmp/x.pmtiles");
+        p.setProperty("storage.provider", "s3");
+        p.setProperty("storage.s3.region", "us-west-2");
+
+        RangeReaderConfig config = RangeReaderConfig.fromProperties(p);
+
+        assertThat(config.uri().toString()).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(config.providerId()).contains("s3");
+        assertThat(config.getParameter("io.tileverse.rangereader.s3.region", String.class))
+                .contains("us-west-2");
+    }
+
+    @Test
+    void fromProperties_canonicalUriAndProviderKeys_parseCorrectly() {
+        Properties p = new Properties();
+        p.setProperty("io.tileverse.rangereader.uri", "file:///tmp/x.pmtiles");
+        p.setProperty("io.tileverse.rangereader.provider", "s3");
+        p.setProperty("io.tileverse.rangereader.s3.region", "us-west-2");
+
+        RangeReaderConfig config = RangeReaderConfig.fromProperties(p);
+
+        assertThat(config.uri().toString()).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(config.providerId()).contains("s3");
+        assertThat(config.getParameter("io.tileverse.rangereader.s3.region", String.class))
+                .contains("us-west-2");
+    }
+
+    @Test
+    void toProperties_emitsOnlyCanonicalKeys() {
+        RangeReaderConfig config = new RangeReaderConfig().uri("file:///tmp/x.pmtiles");
+        config.setParameter("storage.s3.region", "us-west-2");
+        config.providerId("s3");
+
+        Properties out = config.toProperties();
+
+        assertThat(out.stringPropertyNames()).allMatch(k -> !k.startsWith("storage."));
+        assertThat(out.getProperty("io.tileverse.rangereader.uri")).isEqualTo("file:///tmp/x.pmtiles");
+        assertThat(out.getProperty("io.tileverse.rangereader.provider")).isEqualTo("s3");
+        assertThat(out.getProperty("io.tileverse.rangereader.s3.region")).isEqualTo("us-west-2");
+    }
+}


### PR DESCRIPTION
The `1.4` series migrates configuration keys from `io.tileverse.rangereader.<group>.<name>` to `storage.<group>.<name>` (#46). To keep data directories interoperable GeoServer `3.0` (bundled against tileverse 1.3.6) must keep reading a catalog last touched by GeoServer `3.1` (tileverse `1.4`) and vice versa. This commit teaches `1.3.x` to silently rewrite incoming `storage.*` keys to the canonical `1.3.x` form.

- `RangeReaderConfig`: add `KEY_PREFIX` (`"io.tileverse.rangereader."`) and `STORAGE_KEY_PREFIX` (`"storage."`) constants, along with public `normalizeKey` and `normalizeKeys` helpers. The `URI_KEY` and `PROVIDER_ID_KEY` constants now derive from `KEY_PREFIX` so the canonical output form is unchanged.
- `setParameter`, `getParameter`, and `fromProperties` normalize incoming keys so callers can use either prefix interchangeably.
- `fromProperties` also accepts `STORAGE_URI_KEY` and `STORAGE_PROVIDER_ID_KEY` (`storage.uri` / `storage.provider`) as aliases on read.
- `toProperties` still emits only the canonical `1.3.x` form, so outbound data is unchanged.
- No provider keys or other behaviour changes; no geotools or geoserver updates required.
