### PR TITLE
actions: declare explicit permissions on workflow files

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   build-preview:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,6 +43,9 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,6 +12,9 @@ on:
       - 'docs/**'
       - '**.md'
 
+permissions:
+  contents: read
+
 # cancel in-progress jobs or runs for this workflow for the same pr or branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,6 +8,9 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Make the GITHUB_TOKEN scope each workflow uses explicit at the top level instead of relying on the repository default. Read-only where nothing in the workflow writes back to the repo.

- docs-preview.yml: drop redundant top-level issues: write; PR comments only need pull-requests: write (which is already declared). Final top-level scopes: contents: read, pull-requests: write.
- integration.yml: add top-level contents: read. Workflow only checks out repos and runs Maven against external services.
- pr-validation.yml: add top-level contents: read. Workflow runs builds and uploads test-result artifacts; no GitHub API writes.
- publish-snapshot.yml: add top-level contents: read. Workflow checks out, signs with GPG, and deploys to Maven Central using external credentials; no GitHub API writes.

Workflows that already declared appropriate scopes are left as-is (backport.yaml, docs-maintenance.yml, docs.yml, publish-release.yml).