### PR TITLE
storage: add Requester Pays support to S3 and GCS backends

### DIFF
--- a/docs/src/storage/rangereader/user-guide/authentication.md
+++ b/docs/src/storage/rangereader/user-guide/authentication.md
@@ -385,6 +385,60 @@ try (Storage storage = StorageFactory.open(URI.create("gs://my-bucket/"), props)
 
 When a host override is in effect, credentials default to anonymous (the emulator typically doesn't validate them).
 
+## Requester Pays buckets
+
+Some publicly accessible buckets are configured for **Requester Pays**: the bucket owner pays for storage, and the
+**requester** pays for egress and per-operation costs. Hitting such a bucket without the protocol-level opt-in returns
+`403 Forbidden` (S3) or `400 UserProjectMissing` (GCS).
+
+!!! warning "Authentication is required"
+    Requester Pays cannot be combined with anonymous access on either S3 or GCS. The cloud needs an authenticated
+    identity to determine who to bill. Configure real credentials (default chain, named profile, static key, or
+    SDK injection) before enabling these parameters.
+
+    - S3: AWS rejects anonymous (unsigned) requests against Requester Pays buckets unconditionally. Do not set
+      `storage.s3.requester-pays=true` together with `storage.s3.anonymous=true`.
+    - GCS: the requester must be an authenticated principal that holds `serviceusage.services.use` on the project
+      named in `storage.gcs.user-project`. Anonymous calls cannot satisfy either requirement.
+
+### S3
+
+Set `storage.s3.requester-pays=true` to add `x-amz-request-payer: requester` to every request:
+
+```java
+Properties props = new Properties();
+props.setProperty("storage.s3.requester-pays", "true");
+// Requester Pays buckets reject unsigned requests; supply real credentials (the requester's, not the bucket owner's).
+props.setProperty("storage.s3.use-default-credentials-provider", "true");
+props.setProperty("storage.s3.region", "us-east-1");
+
+URI uri = URI.create("s3://noaa-nexrad-level2/2024/01/01/KAMA/");
+try (Storage storage = StorageFactory.open(uri, props)) {
+    // stat / list / openRangeReader / ... succeed and the requester is billed
+}
+```
+
+The flag is silently ignored by regular buckets, so it is safe to set unconditionally for callers that may target both.
+
+### GCS
+
+Set `storage.gcs.user-project=<billing-project-id>` to attach `userProject=<id>` to every request, alongside an
+authenticated credentials chain that has `serviceusage.services.use` on that project:
+
+```java
+Properties props = new Properties();
+props.setProperty("storage.gcs.user-project", "my-billing-project");
+// Requester Pays needs authenticated credentials on the billing project.
+props.setProperty("storage.gcs.default-credentials-chain", "true");
+
+URI uri = URI.create("gs://requester-pays-public-bucket/path/data.bin");
+try (Storage storage = StorageFactory.open(uri, props)) {
+    // ...
+}
+```
+
+Azure has no equivalent billing model and is not affected.
+
 ## Sensitive parameters
 
 Parameters carrying secrets are flagged with `password=true` on their `StorageParameter` declaration. Tools that render

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorage.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorage.java
@@ -22,9 +22,12 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.Storage.BucketGetOption;
 import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.Storage.SignUrlOption;
 import com.google.cloud.storage.StorageException;
@@ -67,6 +70,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -87,23 +91,30 @@ final class GoogleCloudStorage implements Storage {
     private final GcsClientHandle handle;
     private final StorageCapabilities capabilities;
     private final boolean isHns;
+    private final Optional<String> userProject;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    GoogleCloudStorage(URI baseUri, SdkStorageLocation location, SdkStorageCache.Lease lease) {
-        this(baseUri, location, new LeasedGcsHandle(lease));
+    GoogleCloudStorage(
+            URI baseUri, SdkStorageLocation location, SdkStorageCache.Lease lease, Optional<String> userProject) {
+        this(baseUri, location, new LeasedGcsHandle(lease), userProject);
     }
 
-    GoogleCloudStorage(URI baseUri, SdkStorageLocation location, GcsClientHandle handle) {
+    GoogleCloudStorage(URI baseUri, SdkStorageLocation location, GcsClientHandle handle, Optional<String> userProject) {
         this.baseUri = baseUri;
         this.location = location;
         this.handle = handle;
-        this.isHns = detectHns(handle.client(), location.bucket());
+        this.userProject = userProject;
+        this.isHns = detectHns(handle.client(), location.bucket(), userProject);
         this.capabilities = buildCapabilities(this.isHns);
     }
 
-    private static boolean detectHns(com.google.cloud.storage.Storage client, String bucket) {
+    private static boolean detectHns(
+            com.google.cloud.storage.Storage client, String bucket, Optional<String> userProject) {
         try {
-            Bucket b = client.get(bucket);
+            BucketGetOption[] opts = userProject
+                    .map(p -> new BucketGetOption[] {BucketGetOption.userProject(p)})
+                    .orElseGet(() -> new BucketGetOption[0]);
+            Bucket b = client.get(bucket, opts);
             if (b == null) {
                 return false;
             }
@@ -112,6 +123,14 @@ final class GoogleCloudStorage implements Storage {
         } catch (StorageException e) {
             return false;
         }
+    }
+
+    /**
+     * Appends a {@code userProject} option of the requested type when this Storage is configured for a Requester Pays
+     * bucket. Centralised so the conditional does not have to be repeated at every per-call site.
+     */
+    private <O> void addUserProject(List<O> opts, Function<String, O> factory) {
+        userProject.ifPresent(p -> opts.add(factory.apply(p)));
     }
 
     private static StorageCapabilities buildCapabilities(boolean isHns) {
@@ -179,7 +198,9 @@ final class GoogleCloudStorage implements Storage {
     public Optional<StorageEntry.File> stat(String key) {
         requireOpen();
         try {
-            Blob blob = handle.client().get(blobId(key));
+            List<BlobGetOption> getOpts = new ArrayList<>();
+            addUserProject(getOpts, BlobGetOption::userProject);
+            Blob blob = handle.client().get(blobId(key), getOpts.toArray(BlobGetOption[]::new));
             if (blob == null) {
                 return Optional.empty();
             }
@@ -222,6 +243,7 @@ final class GoogleCloudStorage implements Storage {
             opts.add(BlobListOption.currentDirectory());
         }
         options.pageSize().ifPresent(p -> opts.add(BlobListOption.pageSize(p)));
+        addUserProject(opts, BlobListOption::userProject);
 
         Page<Blob> page;
         Iterator<Blob> rawItems;
@@ -289,7 +311,8 @@ final class GoogleCloudStorage implements Storage {
         if (stat(key).isEmpty()) {
             throw new NotFoundException("Blob not found: gs://" + location.bucket() + "/" + location.resolve(key));
         }
-        return new GoogleCloudStorageRangeReader(handle.client(), location.bucket(), location.resolve(key));
+        return new GoogleCloudStorageRangeReader(
+                handle.client(), location.bucket(), location.resolve(key), userProject);
     }
 
     /**
@@ -319,7 +342,9 @@ final class GoogleCloudStorage implements Storage {
             generation = Long.parseLong(options.versionId().orElseThrow());
         }
         BlobId id = blobId(key, generation);
-        Blob blob = handle.client().get(id);
+        List<BlobGetOption> getOpts = new ArrayList<>();
+        addUserProject(getOpts, BlobGetOption::userProject);
+        Blob blob = handle.client().get(id, getOpts.toArray(BlobGetOption[]::new));
         if (blob == null) {
             String absoluteKey = location.resolve(key);
             throw new NotFoundException("Blob not found: gs://%s/%s".formatted(location.bucket(), absoluteKey));
@@ -422,6 +447,7 @@ final class GoogleCloudStorage implements Storage {
         if (options.ifNotExists()) {
             opts.add(BlobTargetOption.doesNotExist());
         }
+        addUserProject(opts, BlobTargetOption::userProject);
         try {
             handle.client().create(bib.build(), data, opts.toArray(BlobTargetOption[]::new));
         } catch (StorageException e) {
@@ -446,6 +472,7 @@ final class GoogleCloudStorage implements Storage {
         if (options.ifNotExists()) {
             opts.add(BlobWriteOption.doesNotExist());
         }
+        addUserProject(opts, BlobWriteOption::userProject);
         try {
             handle.client().createFrom(bib.build(), source, opts.toArray(BlobWriteOption[]::new));
         } catch (StorageException e) {
@@ -472,6 +499,7 @@ final class GoogleCloudStorage implements Storage {
         if (options.ifNotExists()) {
             opts.add(BlobWriteOption.doesNotExist());
         }
+        addUserProject(opts, BlobWriteOption::userProject);
         WriteChannel writer = handle.client().writer(bib.build(), opts.toArray(BlobWriteOption[]::new));
         OutputStream sink = Channels.newOutputStream(writer);
         return new FilterOutputStream(sink) {
@@ -504,7 +532,9 @@ final class GoogleCloudStorage implements Storage {
     public void delete(String key) {
         requireOpen();
         try {
-            handle.client().delete(blobId(key));
+            List<BlobSourceOption> opts = new ArrayList<>();
+            addUserProject(opts, BlobSourceOption::userProject);
+            handle.client().delete(blobId(key), opts.toArray(BlobSourceOption[]::new));
         } catch (StorageException e) {
             throw SdkExceptionMapper.map(e, key);
         }
@@ -518,22 +548,47 @@ final class GoogleCloudStorage implements Storage {
         Set<String> deleted = new HashSet<>();
         Set<String> didNotExist = new HashSet<>();
         Map<String, io.tileverse.storage.StorageException> failed = new HashMap<>();
-        try {
-            List<Boolean> results = handle.client().delete(ids);
-            for (int i = 0; i < results.size(); i++) {
-                String key = keyList.get(i);
-                if (Boolean.TRUE.equals(results.get(i))) {
-                    deleted.add(key);
-                } else {
-                    didNotExist.add(key);
-                }
-            }
-        } catch (StorageException e) {
-            for (String key : keyList) {
-                failed.put(key, SdkExceptionMapper.map(e, key));
+        List<Boolean> results = bulkDelete(ids, keyList, failed);
+        for (int i = 0; i < results.size(); i++) {
+            String key = keyList.get(i);
+            if (Boolean.TRUE.equals(results.get(i))) {
+                deleted.add(key);
+            } else if (!failed.containsKey(key)) {
+                didNotExist.add(key);
             }
         }
         return new DeleteResult(deleted, didNotExist, failed);
+    }
+
+    /**
+     * GCS's {@code delete(Iterable<BlobId>)} accepts no per-call options, so when this Storage is configured for a
+     * Requester Pays bucket we fall back to a per-id loop that attaches {@code userProject} to each request. The shape
+     * of the result list is preserved in either case so the caller's index-based correlation still works.
+     */
+    private List<Boolean> bulkDelete(
+            List<BlobId> ids, List<String> keyList, Map<String, io.tileverse.storage.StorageException> failed) {
+        if (userProject.isEmpty()) {
+            try {
+                return handle.client().delete(ids);
+            } catch (StorageException e) {
+                for (String key : keyList) {
+                    failed.put(key, SdkExceptionMapper.map(e, key));
+                }
+                return List.of();
+            }
+        }
+        List<Boolean> results = new ArrayList<>(ids.size());
+        BlobSourceOption userProjectOption = BlobSourceOption.userProject(userProject.orElseThrow());
+        for (int i = 0; i < ids.size(); i++) {
+            String key = keyList.get(i);
+            try {
+                results.add(handle.client().delete(ids.get(i), userProjectOption));
+            } catch (StorageException e) {
+                results.add(Boolean.FALSE);
+                failed.put(key, SdkExceptionMapper.map(e, key));
+            }
+        }
+        return results;
     }
 
     @Override
@@ -559,11 +614,16 @@ final class GoogleCloudStorage implements Storage {
             throw new PreconditionFailedException("Destination already exists: " + dstKey);
         }
         try {
-            CopyRequest req = CopyRequest.newBuilder()
-                    .setSource(blobId(srcKey))
-                    .setTarget(BlobId.of(dst.location.bucket(), dst.location.resolve(dstKey)))
-                    .build();
-            handle.client().copy(req).getResult();
+            BlobId targetId = BlobId.of(dst.location.bucket(), dst.location.resolve(dstKey));
+            CopyRequest.Builder reqBuilder = CopyRequest.newBuilder().setSource(blobId(srcKey));
+            if (userProject.isPresent()) {
+                String p = userProject.orElseThrow();
+                reqBuilder.setSourceOptions(BlobSourceOption.userProject(p));
+                reqBuilder.setTarget(targetId, BlobTargetOption.userProject(p));
+            } else {
+                reqBuilder.setTarget(targetId);
+            }
+            handle.client().copy(reqBuilder.build()).getResult();
         } catch (StorageException e) {
             throw SdkExceptionMapper.map(e, srcKey);
         }
@@ -588,13 +648,12 @@ final class GoogleCloudStorage implements Storage {
         }
         try {
             BlobInfo info = BlobInfo.newBuilder(blobId(key)).build();
+            List<SignUrlOption> signOpts = new ArrayList<>();
+            signOpts.add(SignUrlOption.withV4Signature());
+            signOpts.add(SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.GET));
+            userProject.ifPresent(p -> signOpts.add(SignUrlOption.withQueryParams(Map.of("userProject", p))));
             return URI.create(handle.client()
-                    .signUrl(
-                            info,
-                            ttl.toSeconds(),
-                            TimeUnit.SECONDS,
-                            SignUrlOption.withV4Signature(),
-                            SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.GET))
+                    .signUrl(info, ttl.toSeconds(), TimeUnit.SECONDS, signOpts.toArray(SignUrlOption[]::new))
                     .toString());
         } catch (StorageException e) {
             throw SdkExceptionMapper.map(e, key);
@@ -611,13 +670,12 @@ final class GoogleCloudStorage implements Storage {
         try {
             BlobInfo.Builder bib = BlobInfo.newBuilder(blobId(key));
             options.contentType().ifPresent(bib::setContentType);
+            List<SignUrlOption> signOpts = new ArrayList<>();
+            signOpts.add(SignUrlOption.withV4Signature());
+            signOpts.add(SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.PUT));
+            userProject.ifPresent(p -> signOpts.add(SignUrlOption.withQueryParams(Map.of("userProject", p))));
             return URI.create(handle.client()
-                    .signUrl(
-                            bib.build(),
-                            ttl.toSeconds(),
-                            TimeUnit.SECONDS,
-                            SignUrlOption.withV4Signature(),
-                            SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.PUT))
+                    .signUrl(bib.build(), ttl.toSeconds(), TimeUnit.SECONDS, signOpts.toArray(SignUrlOption[]::new))
                     .toString());
         } catch (StorageException e) {
             throw SdkExceptionMapper.map(e, key);

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageProvider.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageProvider.java
@@ -91,7 +91,7 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
      */
     public static Storage open(@NonNull URI uri, @NonNull com.google.cloud.storage.Storage client) {
         SdkStorageLocation location = SdkStorageLocation.parse(uri);
-        return new GoogleCloudStorage(uri, location, new BorrowedGcsHandle(client));
+        return new GoogleCloudStorage(uri, location, new BorrowedGcsHandle(client), Optional.empty());
     }
 
     /** Project ID is a unique, user-defined identifier for a Google Cloud project. */
@@ -148,6 +148,35 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
             .build();
 
     /**
+     * Billing project to attach to every operation against a Requester Pays bucket. When set, every GCS request appends
+     * {@code userProject=<value>} so the requester (rather than the bucket owner) is billed for egress and
+     * per-operation costs. Required to access buckets configured with the Requester Pays billing model; without it such
+     * buckets respond with {@code 400 UserProjectMissing}.
+     *
+     * <p><b>Authentication is mandatory.</b> The requester must be an authenticated principal (service account or end
+     * user) that holds {@code serviceusage.services.use} on the project named here; anonymous calls cannot satisfy
+     * either requirement. Enable {@link #GCS_USE_DEFAULT_APPLICTION_CREDENTIALS} or inject a configured
+     * {@link com.google.cloud.storage.Storage} client, and do not pair this parameter with a host override that forces
+     * anonymous mode.
+     */
+    public static final StorageParameter<String> GCS_USER_PROJECT = StorageParameter.builder()
+            .key("storage.gcs.user-project")
+            .title("Billing project for Requester Pays buckets")
+            .description("""
+                    Project ID to bill for operations against a Requester Pays bucket. When set, the value is \
+                    attached to every request as the userProject option (URL parameter); buckets in Requester \
+                    Pays mode reject requests without it with 400 UserProjectMissing.
+
+                    Authentication is mandatory: the requester must be an authenticated principal (service \
+                    account or end user) that holds the serviceusage.services.use permission on the named \
+                    billing project. Anonymous requests cannot satisfy that requirement. Enable \
+                    storage.gcs.default-credentials-chain so application default credentials are used.
+                    """)
+            .type(String.class)
+            .group(ID)
+            .build();
+
+    /**
      * Custom GCS endpoint host override (e.g. {@code http://localhost:4443} for fake-gcs-server emulators). When set,
      * the provider talks to this host instead of the default {@code https://storage.googleapis.com}, and credentials
      * default to anonymous unless explicitly configured otherwise.
@@ -166,8 +195,8 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
             .group(ID)
             .build();
 
-    private static final List<StorageParameter<?>> PARAMS =
-            List.of(GCS_PROJECT_ID, GCS_QUOTA_PROJECT_ID, GCS_USE_DEFAULT_APPLICTION_CREDENTIALS, GCS_HOST);
+    private static final List<StorageParameter<?>> PARAMS = List.of(
+            GCS_PROJECT_ID, GCS_QUOTA_PROJECT_ID, GCS_USE_DEFAULT_APPLICTION_CREDENTIALS, GCS_USER_PROJECT, GCS_HOST);
 
     private final SdkStorageCache clientCache = new SdkStorageCache();
 
@@ -240,8 +269,9 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
     public Storage createStorage(StorageConfig config) {
         URI uri = config.baseUri();
         SdkStorageLocation location = SdkStorageLocation.parse(uri);
-        SdkStorageCache.Lease lease = clientCache.acquire(keyFor(config));
-        return new GoogleCloudStorage(uri, location, lease);
+        SdkStorageCache.Key key = keyFor(config);
+        SdkStorageCache.Lease lease = clientCache.acquire(key);
+        return new GoogleCloudStorage(uri, location, lease, key.userProject());
     }
 
     /**
@@ -274,6 +304,7 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
         boolean useDefaultCreds =
                 config.getParameter(GCS_USE_DEFAULT_APPLICTION_CREDENTIALS).orElse(true);
         boolean anonymous = !useDefaultCreds || hostOverride.isPresent();
-        return new SdkStorageCache.Key(hostOverride, projectId, Optional.empty(), anonymous);
+        Optional<String> userProject = config.getParameter(GCS_USER_PROJECT).filter(s -> !s.isBlank());
+        return new SdkStorageCache.Key(hostOverride, projectId, Optional.empty(), anonymous, userProject);
     }
 }

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReader.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReader.java
@@ -21,6 +21,7 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.StorageException;
 import io.tileverse.storage.AbstractRangeReader;
 import io.tileverse.storage.NotFoundException;
@@ -28,6 +29,9 @@ import io.tileverse.storage.RangeReader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.OptionalLong;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,13 +60,15 @@ final class GoogleCloudStorageRangeReader extends AbstractRangeReader implements
      * @param objectName The GCS object name
      * @throws io.tileverse.storage.StorageException If a storage error occurs
      */
-    GoogleCloudStorageRangeReader(Storage storage, String bucket, String objectName) {
+    GoogleCloudStorageRangeReader(Storage storage, String bucket, String objectName, Optional<String> userProject) {
         this.storage = requireNonNull(storage, "Storage client cannot be null");
         this.bucket = requireNonNull(bucket, "Bucket name cannot be null");
         this.objectName = requireNonNull(objectName, "Object name cannot be null");
         BlobId blobId = BlobId.of(bucket, objectName);
+        List<BlobGetOption> getOpts = new ArrayList<>();
+        userProject.ifPresent(p -> getOpts.add(BlobGetOption.userProject(p)));
         try {
-            this.blob = storage.get(blobId);
+            this.blob = storage.get(blobId, getOpts.toArray(BlobGetOption[]::new));
         } catch (StorageException e) {
             throw SdkExceptionMapper.map(e, objectName);
         }

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/SdkStorageCache.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/SdkStorageCache.java
@@ -46,12 +46,14 @@ final class SdkStorageCache {
             Optional<String> hostOverride,
             Optional<String> projectId,
             Optional<String> credentialsSource,
-            boolean anonymous) {
+            boolean anonymous,
+            Optional<String> userProject) {
 
         Key {
             Objects.requireNonNull(hostOverride, "hostOverride");
             Objects.requireNonNull(projectId, "projectId");
             Objects.requireNonNull(credentialsSource, "credentialsSource");
+            Objects.requireNonNull(userProject, "userProject");
         }
     }
 

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageEmulatorIT.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageEmulatorIT.java
@@ -56,7 +56,7 @@ class GoogleCloudStorageEmulatorIT extends StorageTCK {
     private SdkStorageCache.Key keyFor() {
         String emulatorEndpoint = "http://" + gcsEmulator.getHost() + ":" + gcsEmulator.getFirstMappedPort();
         return new SdkStorageCache.Key(
-                Optional.of(emulatorEndpoint), Optional.of("test-project"), Optional.empty(), true);
+                Optional.of(emulatorEndpoint), Optional.of("test-project"), Optional.empty(), true, Optional.empty());
     }
 
     @Override
@@ -68,7 +68,7 @@ class GoogleCloudStorageEmulatorIT extends StorageTCK {
         URI baseUri = URI.create("gs://" + bucket + "/");
         SdkStorageLocation location = SdkStorageLocation.parse(baseUri);
         SdkStorageCache.Lease lease = cache.acquire(keyFor());
-        return new GoogleCloudStorage(baseUri, location, lease);
+        return new GoogleCloudStorage(baseUri, location, lease, Optional.empty());
     }
 
     @Override

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderTest.java
@@ -45,11 +45,34 @@ class GoogleCloudStorageProviderTest {
                         GoogleCloudStorageProvider.GCS_PROJECT_ID,
                         GoogleCloudStorageProvider.GCS_QUOTA_PROJECT_ID,
                         GoogleCloudStorageProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS,
+                        GoogleCloudStorageProvider.GCS_USER_PROJECT,
                         GoogleCloudStorageProvider.GCS_HOST);
 
         StorageConfig defaults = provider.getDefaultConfig();
         assertThat(defaults.getParameter(GoogleCloudStorageProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS))
                 .hasValue(false);
+    }
+
+    @Test
+    void userProjectParameterShape() {
+        assertThat(GoogleCloudStorageProvider.GCS_USER_PROJECT.key()).isEqualTo("storage.gcs.user-project");
+        assertThat(GoogleCloudStorageProvider.GCS_USER_PROJECT.type()).isEqualTo(String.class);
+        assertThat(GoogleCloudStorageProvider.GCS_USER_PROJECT.defaultValue()).isEmpty();
+        assertThat(GoogleCloudStorageProvider.GCS_USER_PROJECT.group()).isEqualTo(GoogleCloudStorageProvider.ID);
+    }
+
+    @Test
+    void userProjectFlowsIntoCacheKey() {
+        StorageConfig config = new StorageConfig("gs://bucket/file.bin")
+                .setParameter(GoogleCloudStorageProvider.GCS_USER_PROJECT, "my-billing-project");
+        assertThat(GoogleCloudStorageProvider.keyFor(config).userProject()).hasValue("my-billing-project");
+    }
+
+    @Test
+    void blankUserProjectIsTreatedAsAbsent() {
+        StorageConfig config = new StorageConfig("gs://bucket/file.bin")
+                .setParameter(GoogleCloudStorageProvider.GCS_USER_PROJECT, "   ");
+        assertThat(GoogleCloudStorageProvider.keyFor(config).userProject()).isEmpty();
     }
 
     @Test

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReaderTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReaderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -31,10 +32,12 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.StorageException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,7 +81,7 @@ class GoogleCloudStorageRangeReaderTest {
         currentSeekPosition = 0;
 
         // Make mocks lenient for this test class to avoid unnecessary stubbing errors
-        lenient().when(storage.get(blobId)).thenReturn(blob);
+        lenient().when(storage.get(eq(blobId), any(BlobGetOption[].class))).thenReturn(blob);
         lenient().when(blob.exists()).thenReturn(true);
         lenient().when(blob.getSize()).thenReturn((long) CONTENT_LENGTH);
 
@@ -114,13 +117,13 @@ class GoogleCloudStorageRangeReaderTest {
         });
 
         // Create the reader
-        reader = new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME);
+        reader = new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty());
     }
 
     @Test
     void testGetSize() {
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
-        verify(storage, times(1)).get(BlobId.of(BUCKET, OBJECT_NAME));
+        verify(storage, times(1)).get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class));
     }
 
     @Test
@@ -208,7 +211,8 @@ class GoogleCloudStorageRangeReaderTest {
         // Override the default behavior for this specific test
         when(blob.exists()).thenReturn(false);
 
-        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME).size())
+        assertThatThrownBy(
+                        () -> new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty()).size())
                 .isInstanceOf(io.tileverse.storage.NotFoundException.class);
     }
 
@@ -239,20 +243,21 @@ class GoogleCloudStorageRangeReaderTest {
     void testGetSizeFromCachedValue() {
         // First call should query the blob
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
-        verify(storage, times(1)).get(BlobId.of(BUCKET, OBJECT_NAME));
+        verify(storage, times(1)).get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class));
 
         // Second call should use cached value
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
-        verify(storage, times(1)).get(BlobId.of(BUCKET, OBJECT_NAME)); // Still only one call
+        verify(storage, times(1))
+                .get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class)); // Still only one call
     }
 
     @Test
     void testNullInputsInConstructor() {
-        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(null, BUCKET, OBJECT_NAME))
+        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(null, BUCKET, OBJECT_NAME, Optional.empty()))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, null, OBJECT_NAME))
+        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, null, OBJECT_NAME, Optional.empty()))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, BUCKET, null))
+        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, BUCKET, null, Optional.empty()))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRequesterPaysTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRequesterPaysTest.java
@@ -1,0 +1,268 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.CopyWriter;
+import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.Storage.CopyRequest;
+import com.google.cloud.storage.Storage.SignUrlOption;
+import io.tileverse.storage.CopyOptions;
+import io.tileverse.storage.WriteOptions;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Verifies {@link GoogleCloudStorageProvider#GCS_USER_PROJECT}: every call site attaches a {@code userProject} option
+ * (or, for presigned URLs, a query parameter) when the parameter is set, and attaches nothing when it is unset.
+ *
+ * <p>Implementation detail: the Google Cloud Storage Java SDK has no per-client {@code userProject} setting; the option
+ * must be threaded into each per-call options array. This test mocks {@link com.google.cloud.storage.Storage} and
+ * captures those arrays directly.
+ *
+ * <p>Equality of {@code Blob*Option}/{@code Bucket*Option} relies on the underlying {@code RpcOptVal} record-style
+ * {@code equals/hashCode}, so {@code BlobGetOption.userProject("p")} is comparable to itself across instances.
+ */
+@ExtendWith(MockitoExtension.class)
+class GoogleCloudStorageRequesterPaysTest {
+
+    private static final String BUCKET = "rp-bucket";
+    private static final URI BASE_URI = URI.create("gs://" + BUCKET + "/");
+    private static final String USER_PROJECT = "billing-project";
+
+    @Mock
+    com.google.cloud.storage.Storage client;
+
+    @Mock
+    Blob blob;
+
+    @Mock
+    Bucket bucket;
+
+    @Mock
+    Page<Blob> page;
+
+    @Mock
+    WriteChannel writeChannel;
+
+    @Mock
+    CopyWriter copyWriter;
+
+    @BeforeEach
+    void stubGenericResponses() throws Exception {
+        // Lenient stubs — most tests exercise a subset of these.
+        lenient()
+                .when(client.get(any(BlobId.class), any(BlobGetOption[].class)))
+                .thenReturn(blob);
+        lenient()
+                .when(client.get(any(String.class), any(BucketGetOption[].class)))
+                .thenReturn(bucket);
+        lenient()
+                .when(client.list(any(String.class), any(BlobListOption[].class)))
+                .thenReturn(page);
+        lenient().when(page.iterateAll()).thenReturn(List.of());
+        lenient().when(blob.getSize()).thenReturn(0L);
+        lenient().when(blob.getEtag()).thenReturn("etag");
+        lenient().when(blob.getGeneration()).thenReturn(1L);
+        lenient().when(blob.exists()).thenReturn(true);
+        lenient().when(client.copy(any(CopyRequest.class))).thenReturn(copyWriter);
+        lenient().when(copyWriter.getResult()).thenReturn(blob);
+        lenient().when(client.writer(any(), any(BlobWriteOption[].class))).thenReturn(writeChannel);
+        lenient()
+                .when(client.signUrl(any(), any(Long.class), any(), any(SignUrlOption[].class)))
+                .thenReturn(new URL("https://example.com/signed"));
+    }
+
+    private GoogleCloudStorage openStorage(Optional<String> userProject) {
+        SdkStorageLocation location = SdkStorageLocation.parse(BASE_URI);
+        return new GoogleCloudStorage(BASE_URI, location, new BorrowedGcsHandle(client), userProject);
+    }
+
+    @Test
+    void statSendsUserProject() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.stat("a.bin");
+        }
+        ArgumentCaptor<BlobGetOption[]> captor = ArgumentCaptor.forClass(BlobGetOption[].class);
+        verify(client).get(any(BlobId.class), captor.capture());
+        // The constructor's detectHns also takes BucketGetOption — assert that too.
+        assertThat(captor.getAllValues())
+                .anySatisfy(opts -> assertThat(opts).contains(BlobGetOption.userProject(USER_PROJECT)));
+    }
+
+    @Test
+    void listSendsUserProject() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.list("**", io.tileverse.storage.ListOptions.defaults()).toList();
+        }
+        ArgumentCaptor<BlobListOption[]> captor = ArgumentCaptor.forClass(BlobListOption[].class);
+        verify(client).list(any(String.class), captor.capture());
+        assertThat(captor.getValue()).contains(BlobListOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void putBytesSendsUserProject() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            when(client.create(any(), any(byte[].class), any(BlobTargetOption[].class)))
+                    .thenReturn(blob);
+            storage.put("a.bin", new byte[] {1, 2, 3}, WriteOptions.defaults());
+        }
+        ArgumentCaptor<BlobTargetOption[]> captor = ArgumentCaptor.forClass(BlobTargetOption[].class);
+        verify(client).create(any(), any(byte[].class), captor.capture());
+        assertThat(captor.getValue()).contains(BlobTargetOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void putPathSendsUserProject(@TempDir Path tmp) throws Exception {
+        Path src = tmp.resolve("src.bin");
+        Files.write(src, new byte[] {1});
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.put("a.bin", src, WriteOptions.defaults());
+        }
+        ArgumentCaptor<BlobWriteOption[]> captor = ArgumentCaptor.forClass(BlobWriteOption[].class);
+        verify(client).createFrom(any(), any(Path.class), captor.capture());
+        assertThat(captor.getValue()).contains(BlobWriteOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void openOutputStreamSendsUserProject() throws Exception {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            // Don't actually close the stream — that would trigger our put() pipeline.
+            storage.openOutputStream("a.bin", WriteOptions.defaults());
+        }
+        ArgumentCaptor<BlobWriteOption[]> captor = ArgumentCaptor.forClass(BlobWriteOption[].class);
+        verify(client).writer(any(), captor.capture());
+        assertThat(captor.getValue()).contains(BlobWriteOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void deleteSendsUserProject() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.delete("a.bin");
+        }
+        ArgumentCaptor<BlobSourceOption[]> captor = ArgumentCaptor.forClass(BlobSourceOption[].class);
+        verify(client).delete(any(BlobId.class), captor.capture());
+        assertThat(captor.getValue()).contains(BlobSourceOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void deleteAllUsesPerIdLoopWhenUserProjectSet() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.deleteAll(List.of("a.bin", "b.bin"));
+        }
+        // Each id should be deleted individually with userProject; the bulk overload must NOT be used.
+        verify(client, never()).delete(any(Iterable.class));
+        ArgumentCaptor<BlobSourceOption[]> captor = ArgumentCaptor.forClass(BlobSourceOption[].class);
+        verify(client, org.mockito.Mockito.times(2)).delete(any(BlobId.class), captor.capture());
+        assertThat(captor.getAllValues())
+                .allSatisfy(opts -> assertThat(opts).contains(BlobSourceOption.userProject(USER_PROJECT)));
+    }
+
+    @Test
+    void copyAttachesUserProjectToBothEnds() {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.copy("a.bin", "b.bin", CopyOptions.defaults());
+        }
+        ArgumentCaptor<CopyRequest> captor = ArgumentCaptor.forClass(CopyRequest.class);
+        verify(client).copy(captor.capture());
+        CopyRequest req = captor.getValue();
+        assertThat(req.getSourceOptions()).contains(BlobSourceOption.userProject(USER_PROJECT));
+        assertThat(req.getTargetOptions()).contains(BlobTargetOption.userProject(USER_PROJECT));
+    }
+
+    @Test
+    void presignGetEmbedsUserProjectAsQueryParam() throws Exception {
+        try (GoogleCloudStorage storage = openStorage(Optional.of(USER_PROJECT))) {
+            storage.presignGet("a.bin", Duration.ofMinutes(5));
+        }
+        ArgumentCaptor<SignUrlOption[]> captor = ArgumentCaptor.forClass(SignUrlOption[].class);
+        verify(client).signUrl(any(), any(Long.class), any(), captor.capture());
+        // SignUrlOption has no equals(); compare by reflecting on its package-private (option, value) fields.
+        java.lang.reflect.Field optionField = SignUrlOption.class.getDeclaredField("option");
+        java.lang.reflect.Field valueField = SignUrlOption.class.getDeclaredField("value");
+        optionField.setAccessible(true);
+        valueField.setAccessible(true);
+        boolean hasUserProjectQueryParam = false;
+        for (SignUrlOption opt : captor.getValue()) {
+            String optName = optionField.get(opt).toString();
+            Object value = valueField.get(opt);
+            if ("QUERY_PARAMS".equals(optName)
+                    && value instanceof java.util.Map<?, ?> map
+                    && USER_PROJECT.equals(map.get("userProject"))) {
+                hasUserProjectQueryParam = true;
+                break;
+            }
+        }
+        assertThat(hasUserProjectQueryParam)
+                .as("presignGet must add userProject as a signed query parameter")
+                .isTrue();
+    }
+
+    @Test
+    void noUserProjectMeansNoUserProjectOption() {
+        try (GoogleCloudStorage storage = openStorage(Optional.empty())) {
+            storage.stat("a.bin");
+            storage.delete("a.bin");
+        }
+        ArgumentCaptor<BlobGetOption[]> getCaptor = ArgumentCaptor.forClass(BlobGetOption[].class);
+        verify(client).get(any(BlobId.class), getCaptor.capture());
+        assertThat(getCaptor.getValue())
+                .as("BlobGetOption[] must not carry a userProject when storage.gcs.user-project is unset")
+                .noneMatch(opt -> opt.equals(BlobGetOption.userProject("anything")));
+
+        ArgumentCaptor<BlobSourceOption[]> delCaptor = ArgumentCaptor.forClass(BlobSourceOption[].class);
+        verify(client).delete(any(BlobId.class), delCaptor.capture());
+        assertThat(delCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void detectHnsAttachesUserProjectOnConstruction() {
+        try (GoogleCloudStorage ignored = openStorage(Optional.of(USER_PROJECT))) {
+            // construction triggers detectHns
+        }
+        ArgumentCaptor<BucketGetOption[]> captor = ArgumentCaptor.forClass(BucketGetOption[].class);
+        verify(client).get(any(String.class), captor.capture());
+        assertThat(captor.getValue()).contains(BucketGetOption.userProject(USER_PROJECT));
+    }
+}

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/HNSLiveIT.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/HNSLiveIT.java
@@ -44,8 +44,9 @@ class HNSLiveIT {
         cache = new SdkStorageCache();
         URI baseUri = URI.create("gs://" + bucket + "/");
         SdkStorageLocation location = SdkStorageLocation.parse(baseUri);
-        SdkStorageCache.Key key = new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false);
-        storage = new GoogleCloudStorage(baseUri, location, cache.acquire(key));
+        SdkStorageCache.Key key =
+                new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.empty());
+        storage = new GoogleCloudStorage(baseUri, location, cache.acquire(key), Optional.empty());
     }
 
     @AfterAll

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/SdkStorageCacheTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/SdkStorageCacheTest.java
@@ -25,7 +25,8 @@ class SdkStorageCacheTest {
     @Test
     void sameKeyReturnsSameLease() {
         SdkStorageCache cache = new SdkStorageCache();
-        SdkStorageCache.Key key = new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false);
+        SdkStorageCache.Key key =
+                new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.empty());
         try (SdkStorageCache.Lease a = cache.acquire(key);
                 SdkStorageCache.Lease b = cache.acquire(key)) {
             assertThat(a.client()).isSameAs(b.client());
@@ -35,10 +36,10 @@ class SdkStorageCacheTest {
     @Test
     void differentKeysReturnDifferentClients() {
         SdkStorageCache cache = new SdkStorageCache();
-        SdkStorageCache.Key k1 =
-                new SdkStorageCache.Key(Optional.empty(), Optional.of("proj-a"), Optional.empty(), false);
-        SdkStorageCache.Key k2 =
-                new SdkStorageCache.Key(Optional.empty(), Optional.of("proj-b"), Optional.empty(), false);
+        SdkStorageCache.Key k1 = new SdkStorageCache.Key(
+                Optional.empty(), Optional.of("proj-a"), Optional.empty(), false, Optional.empty());
+        SdkStorageCache.Key k2 = new SdkStorageCache.Key(
+                Optional.empty(), Optional.of("proj-b"), Optional.empty(), false, Optional.empty());
         try (SdkStorageCache.Lease a = cache.acquire(k1);
                 SdkStorageCache.Lease b = cache.acquire(k2)) {
             assertThat(a.client()).isNotSameAs(b.client());
@@ -48,7 +49,8 @@ class SdkStorageCacheTest {
     @Test
     void releasedAtZeroRefcount() {
         SdkStorageCache cache = new SdkStorageCache();
-        SdkStorageCache.Key key = new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false);
+        SdkStorageCache.Key key =
+                new SdkStorageCache.Key(Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.empty());
         SdkStorageCache.Lease a = cache.acquire(key);
         SdkStorageCache.Lease b = cache.acquire(key);
         a.close();
@@ -58,10 +60,19 @@ class SdkStorageCacheTest {
     }
 
     @Test
+    void differentUserProjectsProduceDifferentKeys() {
+        SdkStorageCache.Key k1 = new SdkStorageCache.Key(
+                Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.of("billing-a"));
+        SdkStorageCache.Key k2 = new SdkStorageCache.Key(
+                Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.of("billing-b"));
+        assertThat(k1).isNotEqualTo(k2);
+    }
+
+    @Test
     void anonymousModeBuildsClient() {
         SdkStorageCache cache = new SdkStorageCache();
         SdkStorageCache.Key key = new SdkStorageCache.Key(
-                Optional.of("http://localhost:4443"), Optional.of("test"), Optional.empty(), true);
+                Optional.of("http://localhost:4443"), Optional.of("test"), Optional.empty(), true, Optional.empty());
         try (SdkStorageCache.Lease lease = cache.acquire(key)) {
             assertThat(lease.client()).isNotNull();
         }

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3RangeReader.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3RangeReader.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.RequestPayer;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
@@ -78,6 +79,7 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
 
     private final S3Client s3Client;
     private final S3Reference s3Location;
+    private final boolean requesterPays;
 
     private final OptionalLong contentLength;
 
@@ -86,19 +88,22 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
      *
      * @param s3Client The S3 client to use
      * @param s3Location The S3 reference (bucket + key)
+     * @param requesterPays when {@code true}, every request adds {@code x-amz-request-payer: requester}
      * @throws StorageException If a storage error occurs
      */
-    S3RangeReader(S3Client s3Client, S3Reference s3Location) {
+    S3RangeReader(S3Client s3Client, S3Reference s3Location, boolean requesterPays) {
         this.s3Client = Objects.requireNonNull(s3Client, "S3Client cannot be null");
         this.s3Location = Objects.requireNonNull(s3Location, "S3Location cannot be null");
+        this.requesterPays = requesterPays;
         // Eager HEAD: throw NotFoundException at construction time so callers don't get
         // mid-stream failures, and cache the content length for subsequent size() calls.
         try {
-            HeadObjectRequest headRequest = HeadObjectRequest.builder()
-                    .bucket(s3Location.bucket())
-                    .key(s3Location.key())
-                    .build();
-            HeadObjectResponse headResponse = s3Client.headObject(headRequest);
+            HeadObjectRequest.Builder headBuilder =
+                    HeadObjectRequest.builder().bucket(s3Location.bucket()).key(s3Location.key());
+            if (requesterPays) {
+                headBuilder.requestPayer(RequestPayer.REQUESTER);
+            }
+            HeadObjectResponse headResponse = s3Client.headObject(headBuilder.build());
             Long size = headResponse.contentLength();
             this.contentLength = size == null ? OptionalLong.empty() : OptionalLong.of(size);
         } catch (NoSuchKeyException e) {
@@ -114,12 +119,14 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
     protected int readRangeNoFlip(final long offset, final int actualLength, ByteBuffer target) {
         long rangeEnd = offset + actualLength - 1;
         try {
-            GetObjectRequest rangeRequest = GetObjectRequest.builder()
+            GetObjectRequest.Builder rangeBuilder = GetObjectRequest.builder()
                     .bucket(s3Location.bucket())
                     .key(s3Location.key())
-                    .range("bytes=" + offset + "-" + rangeEnd)
-                    .build();
-            ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(rangeRequest);
+                    .range("bytes=" + offset + "-" + rangeEnd);
+            if (requesterPays) {
+                rangeBuilder.requestPayer(RequestPayer.REQUESTER);
+            }
+            ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(rangeBuilder.build());
             if (objectBytes.response().contentLength() != actualLength) {
                 throw new StorageException("Unexpected content length: got "
                         + objectBytes.response().contentLength()

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3Storage.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3Storage.java
@@ -55,6 +55,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -80,6 +81,7 @@ import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.RequestPayer;
 import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -105,18 +107,31 @@ final class S3Storage implements Storage {
     private final S3ClientHandle handle;
     private final StorageCapabilities capabilities;
     private final boolean isDirectoryBucket;
+    private final boolean requesterPays;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    S3Storage(URI baseUri, S3StorageBucketKey ref, S3ClientCache.Lease lease) {
-        this(baseUri, ref, new LeasedS3Handle(lease));
+    S3Storage(URI baseUri, S3StorageBucketKey ref, S3ClientCache.Lease lease, boolean requesterPays) {
+        this(baseUri, ref, new LeasedS3Handle(lease), requesterPays);
     }
 
-    S3Storage(URI baseUri, S3StorageBucketKey ref, S3ClientHandle handle) {
+    S3Storage(URI baseUri, S3StorageBucketKey ref, S3ClientHandle handle, boolean requesterPays) {
         this.baseUri = baseUri;
         this.ref = ref;
         this.handle = handle;
+        this.requesterPays = requesterPays;
         this.isDirectoryBucket = EXPRESS_BUCKET_PATTERN.matcher(ref.bucket()).matches();
         this.capabilities = buildCapabilities(this.isDirectoryBucket);
+    }
+
+    /**
+     * Applies {@link RequestPayer#REQUESTER} to the given AWS request builder when this Storage is configured for a
+     * Requester Pays bucket. Centralised so the conditional does not have to be repeated at every {@code *.builder()}
+     * call site.
+     */
+    private void applyRequesterPays(Consumer<RequestPayer> setter) {
+        if (requesterPays) {
+            setter.accept(RequestPayer.REQUESTER);
+        }
     }
 
     private S3AsyncClient asyncClient() {
@@ -208,11 +223,10 @@ final class S3Storage implements Storage {
         requireOpen();
         String fullKey = resolve(key);
         try {
-            HeadObjectResponse resp = handle.client()
-                    .headObject(HeadObjectRequest.builder()
-                            .bucket(ref.bucket())
-                            .key(fullKey)
-                            .build());
+            HeadObjectRequest.Builder requestBuilder =
+                    HeadObjectRequest.builder().bucket(ref.bucket()).key(fullKey);
+            applyRequesterPays(requestBuilder::requestPayer);
+            HeadObjectResponse resp = handle.client().headObject(requestBuilder.build());
             return Optional.of(new StorageEntry.File(
                     key,
                     resp.contentLength(),
@@ -249,6 +263,7 @@ final class S3Storage implements Storage {
         if (options.pageSize().isPresent()) {
             requestBuilder.maxKeys(options.pageSize().getAsInt());
         }
+        applyRequesterPays(requestBuilder::requestPayer);
 
         // Force the first page read up-front so wrong-region / missing-bucket / permission
         // errors propagate synchronously as a typed StorageException from the list(...) call
@@ -327,7 +342,7 @@ final class S3Storage implements Storage {
             throw new NotFoundException("Object not found: s3://" + ref.bucket() + "/" + fullKey);
         }
         // Reuse our cached S3Client (which already has the right endpoint, region, credentials).
-        return new S3RangeReader(handle.client(), new S3Reference(null, ref.bucket(), fullKey, null));
+        return new S3RangeReader(handle.client(), new S3Reference(null, ref.bucket(), fullKey, null), requesterPays);
     }
 
     @Override
@@ -349,6 +364,7 @@ final class S3Storage implements Storage {
         }
         options.ifMatchEtag().ifPresent(requestBuilder::ifMatch);
         options.ifModifiedSince().ifPresent(requestBuilder::ifModifiedSince);
+        applyRequesterPays(requestBuilder::requestPayer);
         try {
             // Route through the CRT async client so a large GET (whole-object or large range)
             // can be split across connections internally; the toBlockingInputStream() transformer
@@ -532,11 +548,10 @@ final class S3Storage implements Storage {
         requireOpen();
         String fullKey = resolve(key);
         try {
-            handle.client()
-                    .deleteObject(DeleteObjectRequest.builder()
-                            .bucket(ref.bucket())
-                            .key(fullKey)
-                            .build());
+            DeleteObjectRequest.Builder requestBuilder =
+                    DeleteObjectRequest.builder().bucket(ref.bucket()).key(fullKey);
+            applyRequesterPays(requestBuilder::requestPayer);
+            handle.client().deleteObject(requestBuilder.build());
         } catch (S3Exception e) {
             throw S3ExceptionMapper.map(e, key);
         }
@@ -558,11 +573,11 @@ final class S3Storage implements Storage {
                     .map(k -> ObjectIdentifier.builder().key(resolve(k)).build())
                     .toList();
             try {
-                DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+                DeleteObjectsRequest.Builder deleteObjectsBuilder = DeleteObjectsRequest.builder()
                         .bucket(ref.bucket())
-                        .delete(d -> d.objects(ids).quiet(false))
-                        .build();
-                DeleteObjectsResponse resp = client.deleteObjects(deleteObjectsRequest);
+                        .delete(d -> d.objects(ids).quiet(false));
+                applyRequesterPays(deleteObjectsBuilder::requestPayer);
+                DeleteObjectsResponse resp = client.deleteObjects(deleteObjectsBuilder.build());
                 for (DeletedObject d : resp.deleted()) {
                     deleted.add(ref.relativize(d.key()));
                 }
@@ -610,6 +625,7 @@ final class S3Storage implements Storage {
             requestBuilder.metadataDirective(MetadataDirective.REPLACE);
             requestBuilder.metadata(md);
         });
+        applyRequesterPays(requestBuilder::requestPayer);
         try {
             handle.client().copyObject(requestBuilder.build());
         } catch (S3Exception e) {
@@ -635,7 +651,10 @@ final class S3Storage implements Storage {
         }
         GetObjectPresignRequest presignReq = GetObjectPresignRequest.builder()
                 .signatureDuration(ttl)
-                .getObjectRequest(r -> r.bucket(ref.bucket()).key(resolve(key)))
+                .getObjectRequest(r -> {
+                    r.bucket(ref.bucket()).key(resolve(key));
+                    applyRequesterPays(r::requestPayer);
+                })
                 .build();
         URL url = presigner().presignGetObject(presignReq).url();
         return URI.create(url.toString());
@@ -653,6 +672,7 @@ final class S3Storage implements Storage {
                 .putObjectRequest(b -> {
                     b.bucket(ref.bucket()).key(resolve(key));
                     options.contentType().ifPresent(b::contentType);
+                    applyRequesterPays(b::requestPayer);
                 })
                 .build();
         URL url = presigner().presignPutObject(presignReq).url();
@@ -681,6 +701,7 @@ final class S3Storage implements Storage {
             builder.ifNoneMatch("*");
         }
         options.ifMatchEtag().ifPresent(builder::ifMatch);
+        applyRequesterPays(builder::requestPayer);
         return builder;
     }
 }

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3StorageProvider.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3StorageProvider.java
@@ -102,6 +102,40 @@ public class S3StorageProvider extends AbstractStorageProvider {
             .defaultValue(true)
             .build();
 
+    /**
+     * A {@link StorageParameter} to enable Requester Pays for the bucket. When {@code true}, every request adds the
+     * {@code x-amz-request-payer: requester} header so that the requester (not the bucket owner) is billed for egress
+     * and operations. Required to access buckets configured with the Requester Pays billing model (e.g.
+     * {@code s3://noaa-nexrad-level2/}); without it those buckets reject reads with {@code 403 Forbidden}.
+     *
+     * <p><b>Authentication is mandatory.</b> AWS rejects anonymous (unsigned) requests against Requester Pays buckets
+     * unconditionally; AWS uses the signed identity to determine the account to bill. Combine this flag with real
+     * credentials (default credential chain, named profile, or static access/secret key) and do <i>not</i> combine it
+     * with {@link #S3_ANONYMOUS}.
+     */
+    public static final StorageParameter<Boolean> S3_REQUESTER_PAYS = StorageParameter.builder()
+            .key("storage.s3.requester-pays")
+            .title("Requester Pays bucket")
+            .description("""
+                    When enabled, every S3 request adds the x-amz-request-payer: requester header so that \
+                    the requester (rather than the bucket owner) is billed for egress and per-operation costs.
+
+                    Required to access buckets configured with the Requester Pays billing model. Without the \
+                    header, such buckets respond with 403 Forbidden. Examples include several AWS Open Data \
+                    and NOAA datasets (e.g. s3://noaa-nexrad-level2/).
+
+                    Authentication is mandatory: AWS rejects anonymous (unsigned) requests against Requester \
+                    Pays buckets, since the signed identity is what AWS uses to determine the billed account. \
+                    Combine this flag with real credentials (default credential chain, named profile, or static \
+                    access/secret key) and do not combine it with storage.s3.anonymous=true.
+
+                    The flag has no effect against regular buckets; the header is silently ignored.
+                    """)
+            .type(Boolean.class)
+            .group(ID)
+            .defaultValue(false)
+            .build();
+
     /** Configuration parameter for AWS S3 region. */
     public static final StorageParameter<String> S3_REGION = StorageParameter.builder()
             .key("storage.s3.region")
@@ -236,6 +270,7 @@ public class S3StorageProvider extends AbstractStorageProvider {
 
     static final List<StorageParameter<?>> PARAMS = List.of(
             S3_FORCE_PATH_STYLE,
+            S3_REQUESTER_PAYS,
             S3_REGION,
             S3_ANONYMOUS,
             S3_AWS_ACCESS_KEY_ID,
@@ -300,7 +335,7 @@ public class S3StorageProvider extends AbstractStorageProvider {
             throw new IllegalArgumentException("bundle");
         }
         S3StorageBucketKey ref = S3StorageBucketKey.parse(uri);
-        return new S3Storage(uri, ref, new BorrowedS3Handle(bundle));
+        return new S3Storage(uri, ref, new BorrowedS3Handle(bundle), false);
     }
 
     @Override
@@ -372,7 +407,8 @@ public class S3StorageProvider extends AbstractStorageProvider {
         URI uri = config.baseUri();
         S3StorageBucketKey ref = S3StorageBucketKey.parse(uri);
         S3ClientCache.Lease lease = clientCache.acquire(keyFor(config));
-        return new S3Storage(uri, ref, lease);
+        boolean requesterPays = config.getParameter(S3_REQUESTER_PAYS).orElse(false);
+        return new S3Storage(uri, ref, lease, requesterPays);
     }
 
     /**

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3ExpressLiveIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3ExpressLiveIT.java
@@ -50,7 +50,7 @@ class S3ExpressLiveIT {
         S3StorageBucketKey ref = S3StorageBucketKey.parse(baseUri);
         String region = Optional.ofNullable(System.getenv("AWS_REGION")).orElse("us-west-2");
         S3ClientCache.Key key = S3ClientCache.key(region, null, false, null, null, null, false);
-        storage = new S3Storage(baseUri, ref, cache.acquire(key));
+        storage = new S3Storage(baseUri, ref, cache.acquire(key), false);
     }
 
     @AfterAll

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderTest.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderTest.java
@@ -122,7 +122,7 @@ class S3RangeReaderTest {
         // Create the reader directly via the package-private constructor.
         // The Builder is gone in 2.0; tests in this package construct readers via the
         // package-private constructor (production paths use Storage.openRangeReader).
-        reader = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null));
+        reader = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null), false);
     }
 
     @Test

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
@@ -1,0 +1,243 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.tileverse.storage.RangeReader;
+import io.tileverse.storage.WriteOptions;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+/**
+ * Wire-level verification of {@link S3StorageProvider#S3_REQUESTER_PAYS}: every operation builds an SDK request and the
+ * SDK serialises {@code RequestPayer.REQUESTER} as {@code x-amz-request-payer: requester}. An
+ * {@link ExecutionInterceptor} attached to the sync client records each outgoing {@link SdkHttpRequest}; tests assert
+ * that the header is present (when {@code requesterPays=true}) or absent (when {@code requesterPays=false}) for each
+ * affected operation.
+ *
+ * <p>LocalStack does not enforce the header server-side, so the interceptor is the source of truth; LocalStack's role
+ * is only to make the calls succeed end-to-end.
+ *
+ * <p>Presigned URL header embedding is asserted by inspecting the URL's query string for {@code x-amz-request-payer}
+ * (and confirming it is present in {@code x-amz-signedheaders} when SigV4 chooses to sign it as a header).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@Execution(ExecutionMode.SAME_THREAD)
+class S3RequesterPaysIT {
+
+    @Container
+    @SuppressWarnings("resource")
+    private static LocalStackContainer localstack =
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices(Service.S3);
+
+    private static final String REQUEST_PAYER_HEADER = "x-amz-request-payer";
+
+    private static final List<SdkHttpRequest> capturedRequests = new CopyOnWriteArrayList<>();
+
+    private static final ExecutionInterceptor CAPTURING_INTERCEPTOR = new ExecutionInterceptor() {
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission ctx, ExecutionAttributes attrs) {
+            capturedRequests.add(ctx.httpRequest());
+        }
+    };
+
+    private static S3Client sync;
+    private static S3AsyncClient async;
+    private static S3Presigner presigner;
+    private static S3TransferManager transferManager;
+
+    private String bucket;
+
+    @BeforeAll
+    static void setUp() {
+        StaticCredentialsProvider creds = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey()));
+        sync = S3Client.builder()
+                .endpointOverride(localstack.getEndpoint())
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(creds)
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .overrideConfiguration(o -> o.addExecutionInterceptor(CAPTURING_INTERCEPTOR))
+                .build();
+        async = S3AsyncClient.crtBuilder()
+                .endpointOverride(localstack.getEndpoint())
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(creds)
+                .forcePathStyle(true)
+                .build();
+        transferManager = S3TransferManager.builder().s3Client(async).build();
+        presigner = S3Presigner.builder()
+                .endpointOverride(localstack.getEndpoint())
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(creds)
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (transferManager != null) transferManager.close();
+        if (presigner != null) presigner.close();
+        if (async != null) async.close();
+        if (sync != null) sync.close();
+    }
+
+    @BeforeEach
+    void createBucket() {
+        bucket = "rp-" + UUID.randomUUID().toString().substring(0, 12);
+        sync.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        capturedRequests.clear();
+    }
+
+    @AfterEach
+    void deleteBucket() {
+        try {
+            sync.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+        } catch (Exception ignored) {
+            // best-effort
+        }
+    }
+
+    @Test
+    void requesterPaysHeaderOnEverySyncOperation() throws IOException {
+        try (S3Storage storage = openStorage(true)) {
+            storage.put("a.bin", new byte[] {1, 2, 3}, WriteOptions.defaults());
+            storage.put("b.bin", new byte[] {4, 5}, WriteOptions.defaults());
+            storage.stat("a.bin");
+            try (var stream = storage.list("**")) {
+                stream.toList();
+            }
+            storage.copy("a.bin", "c.bin", io.tileverse.storage.CopyOptions.defaults());
+            storage.delete("c.bin");
+            storage.deleteAll(List.of("a.bin", "b.bin"));
+        }
+
+        // Every captured outgoing request must carry the header.
+        assertThat(capturedRequests).isNotEmpty();
+        assertThat(capturedRequests)
+                .allSatisfy(req -> assertThat(headerValue(req, REQUEST_PAYER_HEADER))
+                        .as("expected header on %s %s", req.method(), req.encodedPath())
+                        .hasValue("requester"));
+    }
+
+    @Test
+    void requesterPaysHeaderOnRangeReader() throws IOException {
+        // Seed an object with requesterPays disabled, then re-open the reader with requesterPays enabled
+        // so the captured requests reflect the read path only.
+        try (S3Storage seed = openStorage(false)) {
+            seed.put("data.bin", new byte[] {1, 2, 3, 4, 5, 6, 7, 8}, WriteOptions.defaults());
+        }
+        capturedRequests.clear();
+
+        try (S3Storage storage = openStorage(true);
+                RangeReader reader = storage.openRangeReader("data.bin")) {
+            ByteBuffer buf = ByteBuffer.allocate(4);
+            reader.readRange(0, 4, buf);
+        }
+
+        // openRangeReader does a stat() (HEAD) then constructs S3RangeReader (HEAD) and reads (GET).
+        assertThat(capturedRequests).isNotEmpty();
+        assertThat(capturedRequests)
+                .allSatisfy(req -> assertThat(headerValue(req, REQUEST_PAYER_HEADER))
+                        .as("expected header on %s %s", req.method(), req.encodedPath())
+                        .hasValue("requester"));
+    }
+
+    @Test
+    void noHeaderWhenRequesterPaysDisabled() throws IOException {
+        try (S3Storage storage = openStorage(false)) {
+            storage.put("a.bin", new byte[] {1, 2, 3}, WriteOptions.defaults());
+            storage.stat("a.bin");
+            try (var stream = storage.list("**")) {
+                stream.toList();
+            }
+            storage.delete("a.bin");
+        }
+
+        assertThat(capturedRequests).isNotEmpty();
+        assertThat(capturedRequests)
+                .allSatisfy(req -> assertThat(headerValue(req, REQUEST_PAYER_HEADER))
+                        .as("expected NO header on %s %s", req.method(), req.encodedPath())
+                        .isEmpty());
+    }
+
+    @Test
+    void presignGetUrlEmbedsRequesterPays() throws IOException {
+        try (S3Storage storage = openStorage(true)) {
+            storage.put("p.bin", new byte[] {9}, WriteOptions.defaults());
+            URI url = storage.presignGet("p.bin", java.time.Duration.ofMinutes(5));
+            // SigV4 either embeds the header value as a query parameter or signs it as a required
+            // header (declared in X-Amz-SignedHeaders). Either form binds the requester-pays
+            // semantics to the URL; assert that one of them is present.
+            String query = url.getQuery() == null ? "" : url.getQuery().toLowerCase();
+            assertThat(query)
+                    .as("presigned URL must commit to requester-pays")
+                    .satisfiesAnyOf(
+                            q -> assertThat((String) q).contains("x-amz-request-payer=requester"),
+                            q -> assertThat((String) q).contains("x-amz-request-payer"));
+        }
+    }
+
+    private S3Storage openStorage(boolean requesterPays) {
+        URI baseUri = URI.create("s3://" + bucket + "/");
+        S3StorageBucketKey ref = S3StorageBucketKey.parse(baseUri);
+        S3ClientBundle bundle = S3ClientBundle.of(sync, async, transferManager, presigner);
+        return new S3Storage(baseUri, ref, new BorrowedS3Handle(bundle), requesterPays);
+    }
+
+    private static Optional<String> headerValue(SdkHttpRequest req, String name) {
+        return req.headers().entrySet().stream()
+                .filter(e -> e.getKey().equalsIgnoreCase(name))
+                .map(java.util.Map.Entry::getValue)
+                .filter(v -> !v.isEmpty())
+                .map(v -> v.get(0))
+                .findFirst();
+    }
+}

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageLocalStackIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageLocalStackIT.java
@@ -97,7 +97,7 @@ class S3StorageLocalStackIT extends StorageTCK {
         URI baseUri = URI.create("s3://" + bucket + "/");
         S3StorageBucketKey ref = S3StorageBucketKey.parse(baseUri);
         S3ClientCache.Lease lease = cache.acquire(keyFor());
-        return new S3Storage(baseUri, ref, lease);
+        return new S3Storage(baseUri, ref, lease, false);
     }
 
     /**

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageMinIOIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageMinIOIT.java
@@ -84,7 +84,7 @@ class S3StorageMinIOIT extends StorageTCK {
         URI baseUri = URI.create("s3://" + bucket + "/");
         S3StorageBucketKey ref = S3StorageBucketKey.parse(baseUri);
         S3ClientCache.Lease lease = cache.acquire(keyFor());
-        return new S3Storage(baseUri, ref, lease);
+        return new S3Storage(baseUri, ref, lease, false);
     }
 
     @Override

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderTest.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderTest.java
@@ -21,6 +21,7 @@ import static io.tileverse.storage.s3.S3StorageProvider.S3_AWS_SECRET_ACCESS_KEY
 import static io.tileverse.storage.s3.S3StorageProvider.S3_DEFAULT_CREDENTIALS_PROFILE;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_FORCE_PATH_STYLE;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_REGION;
+import static io.tileverse.storage.s3.S3StorageProvider.S3_REQUESTER_PAYS;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_USE_DEFAULT_CREDENTIALS_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -82,12 +83,21 @@ class S3StorageProviderTest {
         assertThat(parameters)
                 .isEqualTo(List.of(
                         S3_FORCE_PATH_STYLE,
+                        S3_REQUESTER_PAYS,
                         S3_REGION,
                         S3_ANONYMOUS,
                         S3_AWS_ACCESS_KEY_ID,
                         S3_AWS_SECRET_ACCESS_KEY,
                         S3_USE_DEFAULT_CREDENTIALS_PROVIDER,
                         S3_DEFAULT_CREDENTIALS_PROFILE));
+    }
+
+    @Test
+    void requesterPays_parameterShape() {
+        assertThat(S3_REQUESTER_PAYS.key()).isEqualTo("storage.s3.requester-pays");
+        assertThat(S3_REQUESTER_PAYS.type()).isEqualTo(Boolean.class);
+        assertThat(S3_REQUESTER_PAYS.defaultValue()).hasValue(false);
+        assertThat(S3_REQUESTER_PAYS.group()).isEqualTo(S3StorageProvider.ID);
     }
 
     @Test


### PR DESCRIPTION
# Add Requester Pays support to S3 and GCS backends

- **S3**: new `storage.s3.requester-pays` boolean parameter. When `true`, every request gets `x-amz-request-payer: requester` so the requester (not the bucket owner) is billed. Required to access buckets like `s3://noaa-nexrad-level2/`; without it AWS returns `403 Forbidden`.
- **GCS**: new `storage.gcs.user-project` string parameter. When set, every request attaches `userProject=<value>` so the named project is billed. Required for Requester Pays buckets; without it GCS returns `400 UserProjectMissing`.
- Azure has no equivalent billing model; out of scope.

Both parameters call out that **authentication is mandatory** — anonymous requests are rejected by the cloud since the signed identity is what determines the billed account.

---
Resolves #58.