### PR TITLE
Add raster tile store support for PMTiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
     <slf4j-api.version>2.0.17</slf4j-api.version>
     <zstd-jni.version>1.5.7-6</zstd-jni.version>
     <lombok.version>1.18.46</lombok.version>
+    <!--
+    Fork of luciad/gotson webp-imageio with arm64 macOS natives and active maintenance.
+    See https://github.com/usefulness/webp-imageio
+    -->
+    <webp-imageio.version>0.10.0</webp-imageio.version>
 
     <!-- Test Dependency versions -->
     <assertj.version>3.27.7</assertj.version>
@@ -179,6 +184,13 @@
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
+      </dependency>
+
+      <!-- ImageIO plugin for WebP decoding (PNG/JPEG are JDK-built-in; AVIF intentionally omitted). -->
+      <dependency>
+        <groupId>com.github.usefulness</groupId>
+        <artifactId>webp-imageio</artifactId>
+        <version>${webp-imageio.version}</version>
       </dependency>
 
       <!-- Testing -->

--- a/tileverse-pmtiles/pom.xml
+++ b/tileverse-pmtiles/pom.xml
@@ -93,6 +93,11 @@
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
     </dependency>
+    <!-- ImageIO plugin for WebP-encoded raster tiles; PNG/JPEG come with the JDK. -->
+    <dependency>
+      <groupId>com.github.usefulness</groupId>
+      <artifactId>webp-imageio</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/PMTilesHeader.java
@@ -185,6 +185,38 @@ public record PMTilesHeader(
     }
 
     /**
+     * Returns the IANA media type that corresponds to {@link #tileType()}.
+     *
+     * <p>MVT tiles map to {@code application/vnd.mapbox-vector-tile}, MLT map to
+     * {@code application/vnd.maplibre-vector-tile}. Image tile types map to their standard image MIME type.
+     * {@link #TILETYPE_UNKNOWN} maps to {@code application/octet-stream}.
+     *
+     * @return the MIME type string, never {@code null}
+     */
+    public String tileMimeType() {
+        return switch (tileType) {
+            case TILETYPE_MVT -> "application/vnd.mapbox-vector-tile";
+            case TILETYPE_PNG -> "image/png";
+            case TILETYPE_JPEG -> "image/jpeg";
+            case TILETYPE_WEBP -> "image/webp";
+            case TILETYPE_AVIF -> "image/avif";
+            case TILETYPE_MLT -> "application/vnd.maplibre-vector-tile";
+            default -> "application/octet-stream";
+        };
+    }
+
+    /**
+     * @return {@code true} when {@link #tileType()} is one of {@link #TILETYPE_PNG}, {@link #TILETYPE_JPEG},
+     *     {@link #TILETYPE_WEBP}, {@link #TILETYPE_AVIF}.
+     */
+    public boolean isRasterTileType() {
+        return tileType == TILETYPE_PNG
+                || tileType == TILETYPE_JPEG
+                || tileType == TILETYPE_WEBP
+                || tileType == TILETYPE_AVIF;
+    }
+
+    /**
      * Serializes the header to a byte array.
      *
      * @return A byte array containing the serialized header.

--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/UnsupportedTileTypeException.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/UnsupportedTileTypeException.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.pmtiles;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a caller opens a PMTiles archive with a store that does not handle the archive's tile type. For example,
+ * constructing a {@code PMTilesVectorTileStore} on a raster (PNG/JPEG/WebP/AVIF) archive, or a
+ * {@code PMTilesRasterTileStore} on a vector (MVT) archive.
+ */
+public class UnsupportedTileTypeException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnsupportedTileTypeException(String message) {
+        super(message);
+    }
+}

--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/store/PMTilesRasterTileStore.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/store/PMTilesRasterTileStore.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.pmtiles.store;
+
+import io.tileverse.cache.CacheManager;
+import io.tileverse.geom.BoundingBox2D;
+import io.tileverse.pmtiles.PMTilesHeader;
+import io.tileverse.pmtiles.PMTilesReader;
+import io.tileverse.pmtiles.UnsupportedTileTypeException;
+import io.tileverse.rastertile.store.RasterTileStore;
+import io.tileverse.tiling.matrix.Tile;
+import io.tileverse.tiling.store.TileData;
+import io.tileverse.vectortile.store.WebMercatorTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link RasterTileStore} backed by a PMTiles archive holding image tiles (PNG/JPEG/WebP/AVIF).
+ *
+ * <p>Tile bytes are decoded straight from the underlying channel: {@link PMTilesReader#getTile(long,
+ * io.tileverse.io.IOFunction)} hands an {@link InputStream} to {@link ImageIO#read(InputStream)}, so the encoded
+ * payload never sits in a separately allocated {@code ByteBuffer}. No in-memory decode cache is layered on top because
+ * the bytes are already in their final form and the {@code PMTilesReader}'s directory cache plus the
+ * {@code RangeReader}'s own caching already minimize I/O.
+ *
+ * <p>Construction fails fast with {@link UnsupportedTileTypeException} if the archive does not contain a raster tile
+ * type, so a misconfigured PMTiles URI never silently feeds image bytes to a vector consumer (or vice versa).
+ */
+@NullMarked
+public class PMTilesRasterTileStore extends RasterTileStore {
+
+    private final PMTilesReader reader;
+    private final String mimeType;
+
+    public PMTilesRasterTileStore(PMTilesReader reader) throws UnsupportedTileTypeException {
+        super(PMTilesTileMatrixSet.fromWebMercator(Objects.requireNonNull(reader, "reader")));
+        this.reader = reader;
+        PMTilesHeader header = reader.getHeader();
+        if (!header.isRasterTileType()) {
+            throw new UnsupportedTileTypeException(
+                    "PMTiles archive at %s holds tile type 0x%02X (%s); this store handles only raster tile formats (PNG/JPEG/WebP/AVIF)."
+                            .formatted(reader.getSourceIdentifier(), header.tileType(), header.tileMimeType()));
+        }
+        this.mimeType = header.tileMimeType();
+    }
+
+    public PMTilesRasterTileStore cacheManager(CacheManager cacheManager) {
+        reader.cacheManager(cacheManager);
+        return this;
+    }
+
+    @Override
+    public String mimeType() {
+        return mimeType;
+    }
+
+    @Override
+    public BoundingBox2D getExtent() {
+        return WebMercatorTransform.latLonToWebMercator(reader.getHeader().geographicBoundingBox());
+    }
+
+    @Override
+    public Optional<TileData<RenderedImage>> loadTile(Tile tile) {
+        try {
+            long tileId = reader.getTileId(tile.tileIndex());
+            Optional<RenderedImage> img = reader.getTile(tileId, this::decode);
+            return img.map(i -> new TileData<>(tile, i));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private RenderedImage decode(InputStream in) throws IOException {
+        BufferedImage img = ImageIO.read(in);
+        if (img == null) {
+            throw new IOException("No ImageIO reader available for tile MIME type " + mimeType
+                    + " (missing JDK ImageIO plugin for this format)");
+        }
+        return img;
+    }
+}

--- a/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/store/PMTilesVectorTileStore.java
+++ b/tileverse-pmtiles/src/main/java/io/tileverse/pmtiles/store/PMTilesVectorTileStore.java
@@ -19,7 +19,9 @@ import io.tileverse.cache.CacheManager;
 import io.tileverse.geom.BoundingBox2D;
 import io.tileverse.jackson.databind.pmtiles.v3.PMTilesMetadata;
 import io.tileverse.jackson.databind.tilejson.v3.VectorLayer;
+import io.tileverse.pmtiles.PMTilesHeader;
 import io.tileverse.pmtiles.PMTilesReader;
+import io.tileverse.pmtiles.UnsupportedTileTypeException;
 import io.tileverse.tiling.matrix.Tile;
 import io.tileverse.tiling.store.TileData;
 import io.tileverse.vectortile.model.VectorTile;
@@ -56,10 +58,17 @@ public class PMTilesVectorTileStore extends VectorTileStore {
      * Creates a new PMTiles vector tile store.
      *
      * @param reader the reader for the underlying PMTiles archive
+     * @throws UnsupportedTileTypeException if the archive does not hold MVT tiles
      */
-    public PMTilesVectorTileStore(PMTilesReader reader) {
+    public PMTilesVectorTileStore(PMTilesReader reader) throws UnsupportedTileTypeException {
         super(PMTilesTileMatrixSet.fromWebMercator(reader));
         this.reader = Objects.requireNonNull(reader);
+        PMTilesHeader header = reader.getHeader();
+        if (header.tileType() != PMTilesHeader.TILETYPE_MVT) {
+            throw new UnsupportedTileTypeException(
+                    "PMTiles archive at %s holds tile type 0x%02X (%s); this store handles only MVT (vector) tiles."
+                            .formatted(reader.getSourceIdentifier(), header.tileType(), header.tileMimeType()));
+        }
         VectorTileCodec decoder = new VectorTileCodec();
         this.vectorTileCache = new VectorTileCache(
                 reader.getSourceIdentifier(),

--- a/tileverse-pmtiles/src/test/java/io/tileverse/pmtiles/PMTilesTestData.java
+++ b/tileverse-pmtiles/src/test/java/io/tileverse/pmtiles/PMTilesTestData.java
@@ -43,6 +43,21 @@ public class PMTilesTestData {
         return andorraPmTiles;
     }
 
+    /**
+     * Materialize {@code flowers.pmtiles} into {@code tmpFolder} and return its path. The fixture is a small
+     * WebP-encoded raster pyramid (zoom 0-21, ~7 MB) sourced from https://air.mtn.tw/flowers.pmtiles.
+     */
+    public static Path flowers(Path tmpFolder) throws IOException {
+        Path target = tmpFolder.resolve("flowers.pmtiles");
+        if (!Files.isRegularFile(target)) {
+            try (InputStream in = requireNonNull(
+                    PMTilesReaderTest.class.getResourceAsStream("/io/tileverse/pmtiles/flowers.pmtiles"))) {
+                Files.copy(in, target);
+            }
+        }
+        return target;
+    }
+
     public static RangeReader andorraFileRangeReader(Path tmpFolder) throws IOException {
         Path file = andorra(tmpFolder);
         URI leaf = file.toUri();

--- a/tileverse-pmtiles/src/test/java/io/tileverse/pmtiles/store/PMTilesRasterTileStoreTest.java
+++ b/tileverse-pmtiles/src/test/java/io/tileverse/pmtiles/store/PMTilesRasterTileStoreTest.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.pmtiles.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.tileverse.pmtiles.PMTilesHeader;
+import io.tileverse.pmtiles.PMTilesReader;
+import io.tileverse.pmtiles.PMTilesTestData;
+import io.tileverse.pmtiles.UnsupportedTileTypeException;
+import io.tileverse.tiling.matrix.Tile;
+import io.tileverse.tiling.matrix.TileMatrix;
+import io.tileverse.tiling.matrix.TileMatrixSet;
+import io.tileverse.tiling.pyramid.TileIndex;
+import io.tileverse.tiling.store.TileData;
+import java.awt.image.RenderedImage;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises {@link PMTilesRasterTileStore} against the {@code flowers.pmtiles} fixture, a small WebP raster pyramid
+ * (zoom 0-21, bounds around 121.524 E / 25.014 N). The expected values below match the output of {@code pmtiles show
+ * flowers.pmtiles}.
+ */
+class PMTilesRasterTileStoreTest {
+
+    @TempDir
+    private Path tmpFolder;
+
+    private PMTilesReader flowersReader;
+    private PMTilesRasterTileStore flowersStore;
+
+    @BeforeEach
+    void setup() throws IOException {
+        URI file = PMTilesTestData.flowers(tmpFolder).toUri();
+        this.flowersReader = PMTilesReader.open(file);
+        this.flowersStore = new PMTilesRasterTileStore(flowersReader);
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        if (flowersReader != null) {
+            flowersReader.close();
+        }
+    }
+
+    /** {@code pmtiles show flowers.pmtiles} reports tile type WEBP, min/max zoom 0/21, bounds 121.524 E / 25.014 N. */
+    @Test
+    void headerAdvertisesWebpRaster() {
+        PMTilesHeader header = flowersReader.getHeader();
+        assertThat(header.tileType()).isEqualTo(PMTilesHeader.TILETYPE_WEBP);
+        assertThat(header.isRasterTileType()).isTrue();
+        assertThat(header.tileMimeType()).isEqualTo("image/webp");
+        assertThat(header.minZoom()).isZero();
+        assertThat(header.maxZoom()).isEqualTo((byte) 21);
+    }
+
+    @Test
+    void mimeType() {
+        assertThat(flowersStore.mimeType()).isEqualTo("image/webp");
+    }
+
+    @Test
+    void matrixSetCoversHeaderZoomRange() {
+        TileMatrixSet matrixSet = flowersStore.matrixSet();
+        assertThat(matrixSet.minZoomLevel()).isZero();
+        assertThat(matrixSet.maxZoomLevel()).isEqualTo(21);
+        assertThat(flowersStore.getExtent()).isNotNull();
+    }
+
+    /** The root tile is always populated for archives whose zoom range starts at 0. */
+    @Test
+    void loadRootTileReturnsDecodedImage() {
+        TileMatrix root = flowersStore.matrixSet().getTileMatrix(0);
+        Tile rootTile = root.tile(TileIndex.xyz(0, 0, 0)).orElseThrow();
+
+        Optional<TileData<RenderedImage>> data = flowersStore.loadTile(rootTile);
+
+        assertThat(data).as("root tile must exist").isPresent();
+        RenderedImage img = data.orElseThrow().data();
+        assertThat(img).isNotNull();
+        assertThat(img.getWidth()).isEqualTo(512);
+        assertThat(img.getHeight()).isEqualTo(512);
+    }
+
+    /**
+     * Every tile the archive reports as present must decode to a 256x256 {@link RenderedImage}. Confirms the streaming
+     * decode path works end-to-end with the bundled webp-imageio plugin.
+     */
+    @Test
+    void allArchiveTilesAtLowZoomsDecodeAsImage() {
+        TileMatrixSet matrixSet = flowersStore.matrixSet();
+        for (int z = matrixSet.minZoomLevel(); z <= 5; z++) {
+            int zoom = z;
+            flowersReader.getTileIndicesByZoomLevel(zoom).forEach(index -> {
+                Tile tile = matrixSet.getTileMatrix(zoom).tile(index).orElseThrow();
+                Optional<TileData<RenderedImage>> data = flowersStore.loadTile(tile);
+                assertThat(data).as("archive tile %s should load", index).isPresent();
+                RenderedImage img = data.orElseThrow().data();
+                assertThat(img.getWidth()).isEqualTo(512);
+                assertThat(img.getHeight()).isEqualTo(512);
+            });
+        }
+    }
+
+    @Test
+    void vectorStoreRejectsRasterArchive() {
+        assertThatThrownBy(() -> new PMTilesVectorTileStore(flowersReader))
+                .isInstanceOf(UnsupportedTileTypeException.class)
+                .hasMessageContaining("MVT");
+    }
+}

--- a/tileverse-tilestore/src/main/java/io/tileverse/rastertile/store/RasterTileStore.java
+++ b/tileverse-tilestore/src/main/java/io/tileverse/rastertile/store/RasterTileStore.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.rastertile.store;
+
+import io.tileverse.geom.BoundingBox2D;
+import io.tileverse.tiling.matrix.TileMatrixSet;
+import io.tileverse.tiling.store.AbstractTileStore;
+import java.awt.image.RenderedImage;
+
+/**
+ * Abstract base class for {@link io.tileverse.tiling.store.TileStore} implementations that provide raster image tiles
+ * as decoded {@link RenderedImage}s.
+ *
+ * <p>This is the raster counterpart of {@link io.tileverse.vectortile.store.VectorTileStore}, which exposes the decoded
+ * {@code VectorTile} model rather than raw protobuf bytes. Same idea here: callers get pixels, not encoded bytes. The
+ * implementation streams the tile body straight from the underlying channel into the JDK image decoder, so the encoded
+ * payload never sits in a separately allocated {@code ByteBuffer}.
+ *
+ * <p>The publicly visible payload type is the {@link RenderedImage} interface (not the concrete {@code BufferedImage})
+ * so callers can flow results directly into APIs like {@code GridCoverageFactory.create(String, RenderedImage,
+ * ReferencedEnvelope)} and so the store can later swap in a tile-aware or lazy decoder without breaking the contract.
+ *
+ * <p>Passthrough use cases that need raw encoded bytes (e.g. an HTTP proxy serving WebP straight from S3) should bypass
+ * this store and call the underlying reader's streaming {@code getTile(tileId, IOFunction<InputStream, D>)} overload
+ * with a {@code ByteBuffer}- or {@code byte[]}-producing mapper.
+ */
+public abstract class RasterTileStore extends AbstractTileStore<RenderedImage> {
+
+    protected RasterTileStore(TileMatrixSet matrixSet) {
+        super(matrixSet);
+    }
+
+    /**
+     * Returns the IANA media type of the encoded tile bytes underlying this store (for example {@code "image/png"},
+     * {@code "image/jpeg"}, {@code "image/webp"}, {@code "image/avif"}).
+     *
+     * <p>All tiles in a single archive use the same encoding, so this is a per-store property. The store always returns
+     * decoded {@link RenderedImage}s; the MIME type is exposed for callers that need to set HTTP {@code Content-Type}
+     * headers, choose a writer, or pick an alternative decoder pipeline.
+     *
+     * @return the MIME type string, never null
+     */
+    public abstract String mimeType();
+
+    /**
+     * Returns the overall spatial extent of the data in this store.
+     *
+     * @return the extent in the {@link TileMatrixSet#crsId() TileMatrixSet CRS}
+     */
+    public abstract BoundingBox2D getExtent();
+}

--- a/tileverse-tilestore/src/main/java/io/tileverse/rastertile/store/package-info.java
+++ b/tileverse-tilestore/src/main/java/io/tileverse/rastertile/store/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Raster-tile specialization of the core {@link io.tileverse.tiling.store.TileStore} abstraction.
+ *
+ * <p>{@link io.tileverse.rastertile.store.RasterTileStore} returns decoded {@link java.awt.image.RenderedImage}s with a
+ * per-store {@code mimeType()}. It is the parallel of {@link io.tileverse.vectortile.store.VectorTileStore}, kept in
+ * its own package because the two share no domain surface above {@code AbstractTileStore}.
+ */
+package io.tileverse.rastertile.store;


### PR DESCRIPTION
Introduces a parallel RasterTileStore hierarchy alongside VectorTileStore: both extend AbstractTileStore but specialize the tile payload type. Raster tiles are surfaced as encoded ByteBuffers (PNG/JPEG/WebP/AVIF) with a per-store mimeType(); decoding is the consumer's responsibility, so no in-memory decode cache is layered on top of the RangeReader.

New abstractions in tileverse-tilestore:

- io.tileverse.rastertile.store.RasterTileStore: abstract base extending AbstractTileStore<ByteBuffer> with mimeType() and getExtent().

PMTiles changes:
- PMTilesRasterTileStore: rejects non-raster archives at construction.
- PMTilesHeader.tileMimeType() / isRasterTileType() helpers.
- UnsupportedTileTypeException for cross-store mismatches.
- PMTilesVectorTileStore now fails fast on raster archives instead of silently feeding image bytes to the MVT decoder.

Tests use a new flowers.pmtiles fixture (WebP raster pyramid, zoom 0-21, ~7 MB) imported into tileverse-pmtiles/src/test/resources/.
