### PR TITLE
Upgrade cloud-dependencies-bom:1.0.2->1.0.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,8 +11,20 @@
   <name>Tileverse :: BOM</name>
   <description>Bill of Materials for managing Tileverse module versions</description>
 
+  <properties>
+    <cloud-dependencies-bom.version>1.0.3</cloud-dependencies-bom.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <!-- Cloud SDK dependencies (AWS, Azure, GCS, Jackson 2, convergence overrides) -->
+        <groupId>io.tileverse</groupId>
+        <artifactId>cloud-dependencies-bom</artifactId>
+        <version>${cloud-dependencies-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.tileverse.storage</groupId>
         <artifactId>tileverse-storage-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,12 @@
     <palantirJavaFormat.version>2.90.0</palantirJavaFormat.version>
 
     <!-- Dependency versions -->
-    <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
+    <!--
+      When bumping cloud-dependencies-bom.version, also bump the same property in bom/pom.xml.
+      The published tileverse-bom is flattened with flattenMode=ossrh, which drops <parent>/<properties>
+      and only interpolates the dependencyManagement against the module's own properties, hence it cannot inherit this value.
+    -->
+    <cloud-dependencies-bom.version>1.0.3</cloud-dependencies-bom.version>
     <caffeine.version>3.2.3</caffeine.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <jackson.version>3.1.2</jackson.version>
@@ -115,8 +120,8 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Cloud SDK dependencies (AWS, Azure, GCS, Jackson 2, convergence overrides) -->
       <dependency>
+        <!-- Cloud SDK dependencies (AWS, Azure, GCS, Jackson 2, convergence overrides) -->
         <groupId>io.tileverse</groupId>
         <artifactId>cloud-dependencies-bom</artifactId>
         <version>${cloud-dependencies-bom.version}</version>

--- a/tileverse-storage/azure/pom.xml
+++ b/tileverse-storage/azure/pom.xml
@@ -64,4 +64,33 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-heavy-transports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.netty:*</exclude>
+                    <exclude>com.azure:azure-core-http-netty</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>tileverse-storage-azure uses azure-core-http-jdk-httpclient; Netty must not be on its classpath.</message>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tileverse-storage/gcs/pom.xml
+++ b/tileverse-storage/gcs/pom.xml
@@ -46,4 +46,39 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-heavy-transports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.grpc:*</exclude>
+                    <exclude>io.netty:*</exclude>
+                    <exclude>com.google.api:gax-grpc</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- grpc-api carries io.grpc.Context, needed by the GCS HTTP/JSON path; grpc-context is an empty legacy jar. Neither pulls Netty. -->
+                    <include>io.grpc:grpc-api</include>
+                    <include>io.grpc:grpc-context</include>
+                  </includes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>tileverse-storage-gcs uses the GCS HTTP/JSON transport; the gRPC transport stack and Netty must not be on its classpath.</message>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Excludes gRPC (GCS) and Netty (Azure datalake) transports
