### PR TITLE
fix(http): expose HTTP storage parameters through the provider SPI

### DIFF
--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/http/HttpStorageProvider.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/http/HttpStorageProvider.java
@@ -24,6 +24,7 @@ import io.tileverse.storage.spi.AbstractStorageProvider;
 import io.tileverse.storage.spi.StorageProvider;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -290,6 +291,16 @@ public class HttpStorageProvider extends AbstractStorageProvider {
             .subgroup(SUBGROUP_AUTHENTICATION)
             .build();
 
+    static final List<StorageParameter<?>> PARAMS = List.of(
+            HTTP_CONNECTION_TIMEOUT_MILLIS,
+            HTTP_TRUST_ALL_SSL_CERTIFICATES,
+            HTTP_AUTH_USERNAME,
+            HTTP_AUTH_PASSWORD,
+            HTTP_AUTH_BEARER_TOKEN,
+            HTTP_AUTH_API_KEY_HEADERNAME,
+            HTTP_AUTH_API_KEY,
+            HTTP_AUTH_API_KEY_VALUE_PREFIX);
+
     /**
      * Creates a new HttpRangeReaderProvider with support for caching parameters
      *
@@ -299,6 +310,11 @@ public class HttpStorageProvider extends AbstractStorageProvider {
      */
     public HttpStorageProvider() {
         super(true);
+    }
+
+    @Override
+    protected List<StorageParameter<?>> buildParameters() {
+        return PARAMS;
     }
 
     @Override

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/http/HttpStorageProviderTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/http/HttpStorageProviderTest.java
@@ -161,6 +161,20 @@ class HttpStorageProviderTest {
                 .isInstanceOf(BasicAuthentication.class);
     }
 
+    @Test
+    void getParameters_ExposesHttpAuthAndTuningParameters() {
+        assertThat(provider.getParameters())
+                .contains(
+                        HTTP_CONNECTION_TIMEOUT_MILLIS,
+                        HTTP_TRUST_ALL_SSL_CERTIFICATES,
+                        HTTP_AUTH_USERNAME,
+                        HTTP_AUTH_PASSWORD,
+                        HTTP_AUTH_BEARER_TOKEN,
+                        HTTP_AUTH_API_KEY_HEADERNAME,
+                        HTTP_AUTH_API_KEY,
+                        HTTP_AUTH_API_KEY_VALUE_PREFIX);
+    }
+
     private StorageConfig createConfig(Properties props) {
         props.put(StorageConfig.URI_KEY, TEST_URI);
         return StorageConfig.fromProperties(props);


### PR DESCRIPTION
HttpStorageProvider declared its storage.http.* parameters as fields but never overrode buildParameters(), so getParameters() returned only the caching parameters. Return the HTTP parameters like the S3, Azure, and GCS providers do, making them discoverable by SPI consumers.
