### PR TITLE
test(storage): replace dead protomaps demo URL in online IT

### DIFF
--- a/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryOnlineIT.java
+++ b/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryOnlineIT.java
@@ -127,13 +127,13 @@ class StorageFactoryOnlineIT {
     }
 
     /**
-     * This is an S3-hosted URL with a custom virtual hosted style, not a valid S3 URL, hence {@link StorageFactory}
-     * should use {@link HttpStorageProvider}
+     * A custom-domain HTTPS URL with a single-segment path: the S3 provider cannot parse a bucket and object key out of
+     * it, hence {@link StorageFactory} should use {@link HttpStorageProvider}.
      */
     @Test
-    @DisplayName("HTTPS URL on S3 with invalid path-style falls back to HttpRangeReader")
-    void s3OnlineCustomVirtualHostedStyleFallsBackToHttp() throws IOException {
-        URI uri = URI.create("https://demo-bucket.protomaps.com/v4.pmtiles");
+    @DisplayName("Custom-domain HTTPS URL that isn't a parseable S3 URL falls back to HttpRangeReader")
+    void customDomainUrlNotParseableAsS3FallsBackToHttp() throws IOException {
+        URI uri = URI.create("https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles");
         testFindBestProvider(uri, HttpStorageProvider.class);
         testCreate(new StorageConfig(uri));
     }


### PR DESCRIPTION
demo-bucket.protomaps.com/v4.pmtiles now returns 404, failing StorageFactoryOnlineIT. Point the HTTP-fallback case at the stable pmtiles.io firenze demo file instead.

The single-segment path keeps the test's intent: because the S3 provider cannot parse a bucket and object key out of it, the factory routes the custom-domain HTTPS URL to HttpStorageProvider. Renamed the method, DisplayName, and comment to match (the new host is not S3-backed).

The overture S3 URLs in the sibling tests still resolve and are unchanged.

on-behalf-of: @multiversio <info@multivers.io>