### PR TITLE
feat(storage): consistent endpoint override across S3, Azure, and GCS

### DIFF
--- a/docs/src/storage/how-to/authenticate.md
+++ b/docs/src/storage/how-to/authenticate.md
@@ -371,11 +371,11 @@ try (Storage storage = StorageFactory.open(URI.create("gs://gcp-public-data-land
 
 ### fake-gcs-server (emulators)
 
-Either rely on URI-pattern detection (`http(s)://host/storage/v1/b/...`) or set `storage.gcs.host` explicitly:
+Either rely on URI-pattern detection (`http(s)://host/storage/v1/b/...`) or set `storage.gcs.endpoint` explicitly. The value is a full endpoint URL with scheme, not a bare hostname:
 
 ```java
 Properties props = new Properties();
-props.setProperty("storage.gcs.host", "http://localhost:4443");
+props.setProperty("storage.gcs.endpoint", "http://localhost:4443");
 
 try (Storage storage = StorageFactory.open(URI.create("gs://my-bucket/"), props);
         RangeReader reader = storage.openRangeReader("data.bin")) {
@@ -383,7 +383,9 @@ try (Storage storage = StorageFactory.open(URI.create("gs://my-bucket/"), props)
 }
 ```
 
-When a host override is in effect, credentials default to anonymous (the emulator typically doesn't validate them).
+When an endpoint override is in effect, credentials default to anonymous (the emulator typically doesn't validate them).
+
+The earlier key `storage.gcs.host` is still accepted: it is promoted to `storage.gcs.endpoint` when a configuration is loaded.
 
 ## Requester Pays buckets
 

--- a/docs/src/storage/how-to/configure.md
+++ b/docs/src/storage/how-to/configure.md
@@ -84,6 +84,32 @@ try (Storage storage = S3StorageProvider.open(bucket, s3Client);
 }
 ```
 
+#### Custom endpoint (MinIO and other S3-compatible services)
+
+To target a non-AWS S3-compatible service (MinIO, Ceph RGW, Cloudflare R2, DigitalOcean Spaces, Wasabi, LocalStack) you can either encode the service host into an `http(s)://host/bucket/key` URI, or keep a canonical `s3://bucket/key` URI and set the endpoint out of band with `storage.s3.endpoint`:
+
+```java
+Properties props = new Properties();
+props.setProperty("storage.s3.endpoint", "http://localhost:9000"); // MinIO
+props.setProperty("storage.s3.aws-access-key-id", "minioadmin");
+props.setProperty("storage.s3.aws-secret-access-key", "minioadmin");
+props.setProperty("storage.s3.region", "us-east-1"); // any valid region; the SDK requires one
+
+URI bucket = URI.create("s3://my-bucket/");
+URI leaf = URI.create("s3://my-bucket/planet.pmtiles");
+try (Storage storage = StorageFactory.open(bucket, props);
+        RangeReader reader = storage.openRangeReader(leaf)) {
+    // ...
+}
+```
+
+How `storage.s3.endpoint` interacts with the other S3 parameters:
+
+- **Precedence**: an explicit `storage.s3.endpoint` wins over any endpoint inferred from an `http(s)://host/bucket/key` URI. Leave it unset to use the default AWS endpoints for the region.
+- **`storage.s3.force-path-style`**: defaults to `true` whenever an endpoint override is in effect (from either the parameter or the URI), and `false` for canonical AWS URIs. Most S3-compatible services require path-style. Set `storage.s3.force-path-style` explicitly to override the default.
+- **`storage.s3.region`**: still required by the SDK even for services that ignore it (e.g. MinIO). It falls back to `us-east-1` when neither the parameter nor the URI specifies one. For Cloudflare R2, use `storage.s3.region=auto`.
+- **Credentials** (`storage.s3.anonymous`, `storage.s3.aws-access-key-id` / `storage.s3.aws-secret-access-key`, `storage.s3.default-credentials-profile`, the default chain): fully orthogonal to the endpoint. The endpoint selects the service; credentials select the identity. Static access-key + secret is the usual pairing for self-hosted services.
+
 ### HTTP / HTTPS
 
 The connect timeout and trust-all-certificates flag are configurable via `Properties`:
@@ -102,7 +128,7 @@ try (Storage storage = StorageFactory.open(parent, props);
 }
 ```
 
-For full `HttpClient` customization (custom proxy, executor, SSL context, request timeout per call), build the `HttpClient` yourself and pass it through `HttpStorageProvider.open(URI, HttpClient[, HttpAuthentication])`. The returned `Storage` **borrows** the client; closing the `Storage` does NOT close it. The Properties path (`StorageFactory.open(uri, props)`) instead acquires a refcounted lease from `HttpClientCache`, so identical configs across multiple `Storage` instances share one underlying client.
+For full `HttpClient` customization (custom proxy, executor, SSL context, request timeout per call), build the `HttpClient` yourself and pass it through `HttpStorageProvider.open(URI, HttpClient[, HttpAuthentication])`. The returned `Storage` **borrows** the client; closing the `Storage` does NOT close it. The Properties path (`StorageFactory.open(uri, props)`) instead acquires a refcounted lease from `HttpClientCache`, which lets identical configs across multiple `Storage` instances share one underlying client.
 
 ### Global Properties
 

--- a/docs/src/storage/how-to/use-each-backend.md
+++ b/docs/src/storage/how-to/use-each-backend.md
@@ -107,6 +107,18 @@ try (Storage storage = StorageFactory.open(URI.create(
 
 Authentication uses `DefaultAzureCredential` by default (env vars, managed identity, Azure CLI). Provide `storage.azure.account-key` or `storage.azure.sas-token` in `StorageConfig` for explicit credentials.
 
+The `https://` and `abfs[s]://` URI forms already encode the endpoint in their host. The short-form `az://account/container` URI, by contrast, resolves to the public `https://<account>.blob.core.windows.net` endpoint. Set `storage.azure.endpoint` to redirect it to an emulator, a sovereign cloud (Azure Government, Azure China), or a custom domain. The value is the full Blob service endpoint, including the account where the service expects it in the path (the Azurite emulator embeds the account in the path):
+
+```java
+Properties props = new Properties();
+props.setProperty("storage.azure.endpoint", "http://127.0.0.1:10000/devstoreaccount1"); // Azurite
+props.setProperty("storage.azure.connection-string", "UseDevelopmentStorage=true");
+
+try (Storage storage = StorageFactory.open(URI.create("az://devstoreaccount1/my-container/"), props)) {
+    storage.put("file.bin", new byte[100]);
+}
+```
+
 ## Azure Data Lake Storage Gen2 (HNS)
 
 ```java

--- a/docs/src/storage/how-to/use-each-backend.md
+++ b/docs/src/storage/how-to/use-each-backend.md
@@ -72,6 +72,24 @@ try (Storage storage = StorageFactory.open(
 
 Authentication uses the AWS default credential chain unless you provide `storage.s3.aws-access-key-id` / `storage.s3.aws-secret-access-key` in a `StorageConfig`.
 
+To target an S3-compatible service (MinIO, Ceph, Cloudflare R2, DigitalOcean Spaces, ...) while keeping a canonical `s3://bucket/key` URI, set `storage.s3.endpoint`; path-style addressing is auto-enabled:
+
+```java
+import java.util.Properties;
+
+Properties props = new Properties();
+props.setProperty("storage.s3.endpoint", "http://localhost:9000"); // MinIO
+props.setProperty("storage.s3.aws-access-key-id", "minioadmin");
+props.setProperty("storage.s3.aws-secret-access-key", "minioadmin");
+props.setProperty("storage.s3.region", "us-east-1");
+
+try (Storage storage = StorageFactory.open(URI.create("s3://my-bucket/datasets/"), props)) {
+    storage.put("file.parquet", Path.of("/local/file.parquet"), WriteOptions.defaults());
+}
+```
+
+See [Configure - Custom endpoint](configure.md#custom-endpoint-minio-and-other-s3-compatible-services) for how `storage.s3.endpoint` interacts with `force-path-style`, `region`, and credentials.
+
 ## Azure Blob Storage
 
 ```java
@@ -183,7 +201,7 @@ try {
 
 ## Resource cleanup
 
-Always close `Storage`, the listing `Stream`, and any `InputStream` / `OutputStream` returned by Storage methods. The internal SDK client cache is reference-counted, so closing one `Storage` instance does not affect siblings against the same account.
+Always close `Storage`, the listing `Stream`, and any `InputStream` / `OutputStream` returned by Storage methods. Because the internal SDK client cache is reference-counted, closing one `Storage` instance does not affect siblings against the same account.
 
 ```java
 try (Storage storage = StorageFactory.open(uri);

--- a/docs/src/storage/index.md
+++ b/docs/src/storage/index.md
@@ -213,6 +213,7 @@ Per-backend configuration uses the `storage.*` flat namespace, e.g.:
 | `storage.azure.endpoint` | Azure Blob (redirect `az://` to an emulator, sovereign cloud, or custom domain) |
 | `storage.azure.anonymous=true` | Azure Blob (public containers, no credentials) |
 | `storage.gcs.project-id`, `storage.gcs.default-credentials-chain` | GCS |
+| `storage.gcs.endpoint` | GCS (fake-gcs-server / emulators; full URL, not a hostname) |
 | `storage.http.timeout-millis`, `storage.http.auth-bearer-token` | HTTP |
 
 Legacy `io.tileverse.rangereader.*` keys are still accepted with a one-time WARN per distinct key; migrate to `storage.*` at your convenience.

--- a/docs/src/storage/index.md
+++ b/docs/src/storage/index.md
@@ -20,7 +20,7 @@ The `Storage` API is the recommended entrypoint when you need anything beyond by
 The `s3://` backend transparently handles **any S3-compatible service**, not just AWS. Provider selection works in two ways:
 
 - For an `s3://bucket/key` URI, the S3 backend is selected outright.
-- For an `http(s)://endpoint/bucket/key` URI, the resolver issues a HEAD request and selects the S3 backend if the response carries an `x-amz-*` header (`x-amz-request-id` in particular). All major S3-compatible services do.
+- For an `http(s)://endpoint/bucket/key` URI, the resolver issues a HEAD request and selects the S3 backend if the response returns an `x-amz-*` header (`x-amz-request-id` in particular). All major S3-compatible services do.
 
 Tested or known to work via this path:
 
@@ -40,8 +40,10 @@ Tested or known to work via this path:
 
 Credentials and region come from the same parameters as AWS S3 (`storage.s3.aws-access-key-id`, `storage.s3.aws-secret-access-key`, `storage.s3.region`); the SDK's default credential chain is used when none are set. If the HEAD probe fails (firewalled endpoint, custom auth required to GET headers), force the provider explicitly via `storage.providerId=s3` in the config.
 
+Alternatively, keep a canonical `s3://bucket/key` URI and point it at the custom service with `storage.s3.endpoint` (e.g. `http://localhost:9000` for MinIO). This separates *where the object lives* (the URI) from *where the service is* (the endpoint), and auto-enables path-style addressing. See [Configure - Amazon S3](how-to/configure.md#amazon-s3).
+
 !!! info "Native protocols for OpenStack Swift, Azure Files, FTP, etc. are intentionally not supported"
-    `tileverse-storage`'s scope is *cloud-optimized object storage for the GeoTools/GeoServer ecosystem*. Native OpenStack Swift, Azure Files (SMB), HDFS-via-WebHDFS, FTP, and similar are out of scope: the audience is overwhelmingly served by S3-compatible endpoints (which all of the above offer), and adding alternate-protocol backends would multiply the maintenance surface without serving a real user. See [Why tileverse-storage?](explanation/why.md#when-not-to-use-this-library) for the broader scope rationale.
+    `tileverse-storage`'s scope is *cloud-optimized object storage for the GeoTools/GeoServer ecosystem*. Native OpenStack Swift, Azure Files (SMB), HDFS-via-WebHDFS, FTP, and similar are out of scope: the audience is overwhelmingly served by S3-compatible endpoints (which all of the above offer), and adding alternate-protocol backends would multiply the maintenance burden without serving a real user. See [Why tileverse-storage?](explanation/why.md#when-not-to-use-this-library) for the broader scope rationale.
 
 ## Capability matrix
 
@@ -204,6 +206,7 @@ Per-backend configuration uses the `storage.*` flat namespace, e.g.:
 |---|---|
 | `storage.s3.region` | S3 |
 | `storage.s3.aws-access-key-id`, `storage.s3.aws-secret-access-key` | S3 |
+| `storage.s3.endpoint` | S3 |
 | `storage.s3.force-path-style` | S3 |
 | `storage.azure.account-key`, `storage.azure.sas-token` | Azure Blob |
 | `storage.azure.connection-string` | Azure Blob (Azurite, dev) |

--- a/docs/src/storage/index.md
+++ b/docs/src/storage/index.md
@@ -210,6 +210,7 @@ Per-backend configuration uses the `storage.*` flat namespace, e.g.:
 | `storage.s3.force-path-style` | S3 |
 | `storage.azure.account-key`, `storage.azure.sas-token` | Azure Blob |
 | `storage.azure.connection-string` | Azure Blob (Azurite, dev) |
+| `storage.azure.endpoint` | Azure Blob (redirect `az://` to an emulator, sovereign cloud, or custom domain) |
 | `storage.azure.anonymous=true` | Azure Blob (public containers, no credentials) |
 | `storage.gcs.project-id`, `storage.gcs.default-credentials-chain` | GCS |
 | `storage.http.timeout-millis`, `storage.http.auth-bearer-token` | HTTP |

--- a/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobLocation.java
+++ b/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobLocation.java
@@ -124,6 +124,11 @@ record AzureBlobLocation(String endpoint, String accountName, String container, 
         return p;
     }
 
+    /** Returns a copy targeting the given Blob service endpoint, keeping the account, container, and prefix. */
+    AzureBlobLocation withEndpoint(String endpoint) {
+        return new AzureBlobLocation(endpoint, accountName, container, prefix);
+    }
+
     String resolve(String relativeKey) {
         io.tileverse.storage.Storage.requireSafeKey(relativeKey);
         return prefix + relativeKey;

--- a/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobStorageProvider.java
+++ b/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobStorageProvider.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * {@link StorageProvider} implementation for Azure Blob Storage.
@@ -167,6 +168,37 @@ public class AzureBlobStorageProvider extends AbstractStorageProvider {
             .password(true)
             .build();
 
+    /**
+     * Overrides the Blob service endpoint to let a short-form {@code az://account/container} URI target an emulator
+     * (Azurite), a sovereign cloud (Azure Government, Azure China), or a custom domain instead of the public
+     * {@code https://<account>.blob.core.windows.net} endpoint inferred from the account name.
+     *
+     * <p>When set, it replaces the endpoint derived from the URI. Because the {@code https://} and {@code abfs[s]://}
+     * URI forms already encode the endpoint in their host, this parameter is mainly useful for the {@code az://} short
+     * form.
+     *
+     * <p><b>Key:</b> {@code storage.azure.endpoint}
+     */
+    public static final StorageParameter<URI> AZURE_ENDPOINT = StorageParameter.builder()
+            .key("storage.azure.endpoint")
+            .title("Blob service endpoint")
+            .description("""
+                    Override the Blob service endpoint URL to let a short-form az://account/container URI target \
+                    an emulator, a sovereign cloud, or a custom domain instead of the public \
+                    https://<account>.blob.core.windows.net endpoint.
+
+                    The value is the full Blob service endpoint, including the account where the service expects it in \
+                    the path. For the Azurite emulator that is http://127.0.0.1:10000/devstoreaccount1; for Azure \
+                    Government it is https://<account>.blob.core.usgovcloudapi.net.
+
+                    When set, it replaces the endpoint derived from the URI. Because the https:// and abfs(s):// URI \
+                    forms already encode the endpoint in their host, this parameter is mainly useful for the az:// \
+                    short form. Leave it unset to use the public Azure endpoint for the account.
+                    """)
+            .type(URI.class)
+            .group(ID)
+            .build();
+
     /** Maximum number of retry attempts for Azure SDK requests. Default {@code 3}. */
     public static final StorageParameter<Integer> AZURE_MAX_RETRIES = StorageParameter.builder()
             .key("storage.azure.max-retries")
@@ -214,6 +246,7 @@ public class AzureBlobStorageProvider extends AbstractStorageProvider {
             AZURE_ACCOUNT_KEY,
             AZURE_SAS_TOKEN,
             AZURE_CONNECTION_STRING,
+            AZURE_ENDPOINT,
             AZURE_MAX_RETRIES,
             AZURE_RETRY_DELAY,
             AZURE_MAX_RETRY_DELAY,
@@ -325,9 +358,23 @@ public class AzureBlobStorageProvider extends AbstractStorageProvider {
     @Override
     public Storage createStorage(StorageConfig config) {
         URI uri = config.baseUri();
-        AzureBlobLocation location = AzureBlobLocation.parse(uri);
+        AzureBlobLocation location = locationFor(config);
         AzureClientCache.Lease lease = clientCache.acquire(keyFor(config, location));
         return new AzureBlobStorage(uri, location, lease);
+    }
+
+    /**
+     * Parses the base URI into an {@link AzureBlobLocation}, applying {@link #AZURE_ENDPOINT} when set. The override
+     * then becomes the single source of truth for both the cache key and the {@link AzureBlobStorage}. Package-private
+     * to let unit tests exercise endpoint resolution without acquiring a real SDK client lease.
+     */
+    static AzureBlobLocation locationFor(StorageConfig config) {
+        AzureBlobLocation location = AzureBlobLocation.parse(config.baseUri());
+        Optional<URI> endpointOverride = config.getParameter(AZURE_ENDPOINT);
+        if (endpointOverride.isPresent()) {
+            return location.withEndpoint(endpointOverride.orElseThrow().toString());
+        }
+        return location;
     }
 
     /**

--- a/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobStorageProviderConfigTest.java
+++ b/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobStorageProviderConfigTest.java
@@ -138,4 +138,58 @@ class AzureBlobStorageProviderConfigTest {
         assertThat(AzureBlobStorageProvider.keyFor(a, locationOf(BLOB_URI)))
                 .isNotEqualTo(AzureBlobStorageProvider.keyFor(b, locationOf(BLOB_URI)));
     }
+
+    @Test
+    void endpointOverride_absentKeepsUriDerivedEndpoint() {
+        StorageConfig config = new StorageConfig("az://devstoreaccount1/my-container/file.bin");
+
+        assertThat(AzureBlobStorageProvider.locationFor(config).endpoint())
+                .isEqualTo("https://devstoreaccount1.blob.core.windows.net");
+    }
+
+    @Test
+    void endpointOverride_redirectsAzShortFormToCustomEndpoint() {
+        StorageConfig config = new StorageConfig("az://devstoreaccount1/my-container/file.bin")
+                .setParameter(
+                        AzureBlobStorageProvider.AZURE_ENDPOINT, URI.create("http://127.0.0.1:10000/devstoreaccount1"));
+
+        assertThat(AzureBlobStorageProvider.locationFor(config).endpoint())
+                .isEqualTo("http://127.0.0.1:10000/devstoreaccount1");
+    }
+
+    @Test
+    void endpointOverride_winsOverUriDerivedEndpoint() {
+        StorageConfig config = new StorageConfig(BLOB_URI)
+                .setParameter(
+                        AzureBlobStorageProvider.AZURE_ENDPOINT,
+                        URI.create("https://devstoreaccount1.blob.core.usgovcloudapi.net"));
+
+        assertThat(AzureBlobStorageProvider.locationFor(config).endpoint())
+                .isEqualTo("https://devstoreaccount1.blob.core.usgovcloudapi.net");
+    }
+
+    @Test
+    void endpointOverride_preservesAccountContainerAndPrefix() {
+        StorageConfig config = new StorageConfig("az://devstoreaccount1/my-container/data/")
+                .setParameter(
+                        AzureBlobStorageProvider.AZURE_ENDPOINT, URI.create("http://127.0.0.1:10000/devstoreaccount1"));
+
+        AzureBlobLocation location = AzureBlobStorageProvider.locationFor(config);
+        assertThat(location.accountName()).isEqualTo("devstoreaccount1");
+        assertThat(location.container()).isEqualTo("my-container");
+        assertThat(location.prefix()).isEqualTo("data/");
+    }
+
+    @Test
+    void differentEndpointsProduceDifferentCacheKeys() {
+        StorageConfig a = new StorageConfig("az://devstoreaccount1/my-container")
+                .setParameter(
+                        AzureBlobStorageProvider.AZURE_ENDPOINT, URI.create("http://127.0.0.1:10000/devstoreaccount1"));
+        StorageConfig b = new StorageConfig("az://devstoreaccount1/my-container")
+                .setParameter(
+                        AzureBlobStorageProvider.AZURE_ENDPOINT, URI.create("http://127.0.0.1:10001/devstoreaccount1"));
+
+        assertThat(AzureBlobStorageProvider.keyFor(a, AzureBlobStorageProvider.locationFor(a)))
+                .isNotEqualTo(AzureBlobStorageProvider.keyFor(b, AzureBlobStorageProvider.locationFor(b)));
+    }
 }

--- a/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobStorageProviderTest.java
+++ b/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobStorageProviderTest.java
@@ -63,6 +63,7 @@ class AzureBlobStorageProviderTest {
                         AzureBlobStorageProvider.AZURE_ACCOUNT_KEY,
                         AzureBlobStorageProvider.AZURE_SAS_TOKEN,
                         AzureBlobStorageProvider.AZURE_CONNECTION_STRING,
+                        AzureBlobStorageProvider.AZURE_ENDPOINT,
                         AzureBlobStorageProvider.AZURE_MAX_RETRIES,
                         AzureBlobStorageProvider.AZURE_RETRY_DELAY,
                         AzureBlobStorageProvider.AZURE_MAX_RETRY_DELAY,

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/StorageConfig.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/StorageConfig.java
@@ -52,6 +52,13 @@ public class StorageConfig {
      */
     public static final String LEGACY_KEY_PREFIX = "io.tileverse.rangereader.";
 
+    /**
+     * Parameter keys renamed within the {@code storage.*} namespace, mapping each deprecated key to its canonical
+     * replacement. Applied by {@link #normalizeKey(String)} after legacy-prefix rewriting, which lets both the
+     * legacy-prefixed and the {@code storage.*} spellings of a deprecated key resolve to the new key.
+     */
+    private static final Map<String, String> RENAMED_KEYS = Map.of("storage.gcs.host", "storage.gcs.endpoint");
+
     private static final Set<String> warnedLegacyKeys = ConcurrentHashMap.newKeySet();
 
     /** The canonical key used in {@link Properties} to specify the URI of the resource. */
@@ -415,18 +422,32 @@ public class StorageConfig {
      * @return The normalized key, or {@code key} unchanged if it does not use the legacy prefix.
      */
     public static String normalizeKey(String key) {
-        if (key != null && key.startsWith(LEGACY_KEY_PREFIX)) {
-            String normalized = KEY_PREFIX + key.substring(LEGACY_KEY_PREFIX.length());
+        if (key == null) {
+            return null;
+        }
+        String normalized = key;
+        if (normalized.startsWith(LEGACY_KEY_PREFIX)) {
+            String rewritten = KEY_PREFIX + normalized.substring(LEGACY_KEY_PREFIX.length());
             if (warnedLegacyKeys.add(key)) {
                 log.warn(
                         "Legacy parameter key '{}' -- use '{}'. Legacy keys remain accepted for backwards compatibility; new configurations should use the '{}*' form.",
                         key,
-                        normalized,
+                        rewritten,
                         KEY_PREFIX);
             }
-            return normalized;
+            normalized = rewritten;
         }
-        return key;
+        String renamed = RENAMED_KEYS.get(normalized);
+        if (renamed != null) {
+            if (warnedLegacyKeys.add(normalized)) {
+                log.warn(
+                        "Deprecated parameter key '{}' -- use '{}'. The old key remains accepted for backwards compatibility.",
+                        normalized,
+                        renamed);
+            }
+            normalized = renamed;
+        }
+        return normalized;
     }
 
     /**

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/StorageConfigTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/StorageConfigTest.java
@@ -45,6 +45,25 @@ class RangeReaderConfigTest {
     }
 
     @Test
+    void normalizeKey_renamedGcsHost_promotedToEndpoint() {
+        assertThat(StorageConfig.normalizeKey("storage.gcs.host")).isEqualTo("storage.gcs.endpoint");
+    }
+
+    @Test
+    void normalizeKey_legacyGcsHost_promotedToEndpoint() {
+        assertThat(StorageConfig.normalizeKey("io.tileverse.rangereader.gcs.host"))
+                .isEqualTo("storage.gcs.endpoint");
+    }
+
+    @Test
+    void setParameter_gcsHostKey_storedAsEndpoint() {
+        StorageConfig config =
+                new StorageConfig("gs://bucket/o").setParameter("storage.gcs.host", "http://localhost:4443");
+
+        assertThat(config.getParameter("storage.gcs.endpoint")).hasValue("http://localhost:4443");
+    }
+
+    @Test
     void normalizeKey_null_passthrough() {
         assertThat(StorageConfig.normalizeKey(null)).isNull();
     }

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageProvider.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageProvider.java
@@ -177,26 +177,34 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
             .build();
 
     /**
-     * Custom GCS endpoint host override (e.g. {@code http://localhost:4443} for fake-gcs-server emulators). When set,
-     * the provider talks to this host instead of the default {@code https://storage.googleapis.com}, and credentials
+     * Custom GCS endpoint override (e.g. {@code http://localhost:4443} for fake-gcs-server emulators). When set, the
+     * provider talks to this endpoint instead of the default {@code https://storage.googleapis.com}, and credentials
      * default to anonymous unless explicitly configured otherwise.
      *
-     * <p><b>Key:</b> {@code storage.gcs.host}
+     * <p>The value is a full endpoint URL with scheme (the Google SDK's {@code StorageOptions.Builder.setHost} expects
+     * a URI, not a bare hostname).
+     *
+     * <p><b>Key:</b> {@code storage.gcs.endpoint}
      */
-    public static final StorageParameter<String> GCS_HOST = StorageParameter.builder()
-            .key("storage.gcs.host")
-            .title("Custom GCS endpoint host")
+    public static final StorageParameter<URI> GCS_ENDPOINT = StorageParameter.builder()
+            .key("storage.gcs.endpoint")
+            .title("Custom GCS endpoint")
             .description("""
-                    Custom endpoint host for GCS-compatible servers (e.g. fake-gcs-server: http://localhost:4443). \
-                    When set, the SDK targets this host instead of the public Google endpoint. \
-                    Authentication defaults to anonymous when a host override is in effect.
+                    Custom endpoint for GCS-compatible servers (e.g. fake-gcs-server: http://localhost:4443). \
+                    When set, the SDK targets this endpoint instead of the public Google endpoint. \
+                    The value is a full endpoint URL with scheme, not a bare hostname. \
+                    Authentication defaults to anonymous when an endpoint override is in effect.
                     """)
-            .type(String.class)
+            .type(URI.class)
             .group(ID)
             .build();
 
     private static final List<StorageParameter<?>> PARAMS = List.of(
-            GCS_PROJECT_ID, GCS_QUOTA_PROJECT_ID, GCS_USE_DEFAULT_APPLICTION_CREDENTIALS, GCS_USER_PROJECT, GCS_HOST);
+            GCS_PROJECT_ID,
+            GCS_QUOTA_PROJECT_ID,
+            GCS_USE_DEFAULT_APPLICTION_CREDENTIALS,
+            GCS_USER_PROJECT,
+            GCS_ENDPOINT);
 
     private final SdkStorageCache clientCache = new SdkStorageCache();
 
@@ -278,21 +286,25 @@ public class GoogleCloudStorageProvider extends AbstractStorageProvider {
      * Resolves the {@link SdkStorageCache.Key} cache discriminator for the given config. Package-private so unit tests
      * can exercise host-override / project-id / credential precedence without acquiring a real SDK client lease.
      *
-     * <p>Host-override resolution order:
+     * <p>Endpoint-override resolution order:
      *
      * <ol>
-     *   <li>explicit {@code storage.gcs.host} parameter (used for fake-gcs-server etc.)
+     *   <li>explicit {@code storage.gcs.endpoint} parameter (used for fake-gcs-server etc.); the deprecated
+     *       {@code storage.gcs.host} key is promoted to it by {@link StorageConfig#normalizeKey(String)}
      *   <li>derived from {@code http(s)://host/storage/v1/b/...} emulator-style URIs
      *   <li>none (use the default Google endpoint)
      * </ol>
      *
-     * <p>When a host override is in effect, credentials default to anonymous unless the application default chain is
-     * explicitly enabled.
+     * <p>When an endpoint override is in effect, credentials default to anonymous unless the application default chain
+     * is explicitly enabled.
      */
     static SdkStorageCache.Key keyFor(StorageConfig config) {
         URI uri = config.baseUri();
         Optional<String> projectId = config.getParameter(GCS_PROJECT_ID);
-        Optional<String> hostOverride = config.getParameter(GCS_HOST).filter(s -> !s.isBlank());
+        // Read the endpoint as a string rather than via GCS_ENDPOINT (URI): a blank value (e.g. a promoted blank
+        // storage.gcs.host) must be ignored here instead of failing URI parsing.
+        Optional<String> hostOverride =
+                config.getParameter(GCS_ENDPOINT.key(), String.class).filter(s -> !s.isBlank());
         if (hostOverride.isEmpty()) {
             String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
             if ((scheme.equals("http") || scheme.equals("https"))

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderConfigTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderConfigTest.java
@@ -31,16 +31,23 @@ class GoogleCloudStorageProviderConfigTest {
     private static final URI GS_URI = URI.create("gs://my-bucket/file.bin");
 
     @Test
-    void hostOverride_explicitParameterWins() {
-        StorageConfig config =
-                new StorageConfig(GS_URI).setParameter(GoogleCloudStorageProvider.GCS_HOST, "http://localhost:4443");
+    void endpoint_explicitParameterWins() {
+        StorageConfig config = new StorageConfig(GS_URI)
+                .setParameter(GoogleCloudStorageProvider.GCS_ENDPOINT, URI.create("http://localhost:4443"));
 
         assertThat(GoogleCloudStorageProvider.keyFor(config).hostOverride()).hasValue("http://localhost:4443");
     }
 
     @Test
-    void hostOverride_blankParameterIgnored() {
-        StorageConfig config = new StorageConfig(GS_URI).setParameter(GoogleCloudStorageProvider.GCS_HOST, "  ");
+    void legacyHostKey_promotedToEndpoint() {
+        StorageConfig config = new StorageConfig(GS_URI).setParameter("storage.gcs.host", "http://localhost:4443");
+
+        assertThat(GoogleCloudStorageProvider.keyFor(config).hostOverride()).hasValue("http://localhost:4443");
+    }
+
+    @Test
+    void blankEndpointIgnored() {
+        StorageConfig config = new StorageConfig(GS_URI).setParameter("storage.gcs.host", "  ");
 
         assertThat(GoogleCloudStorageProvider.keyFor(config).hostOverride()).isEmpty();
     }
@@ -69,8 +76,8 @@ class GoogleCloudStorageProviderConfigTest {
 
     @Test
     void anonymousMode_whenHostOverridePresent() {
-        StorageConfig config =
-                new StorageConfig(GS_URI).setParameter(GoogleCloudStorageProvider.GCS_HOST, "http://localhost:4443");
+        StorageConfig config = new StorageConfig(GS_URI)
+                .setParameter(GoogleCloudStorageProvider.GCS_ENDPOINT, URI.create("http://localhost:4443"));
 
         assertThat(GoogleCloudStorageProvider.keyFor(config).anonymous()).isTrue();
     }
@@ -102,11 +109,11 @@ class GoogleCloudStorageProviderConfigTest {
     }
 
     @Test
-    void differentHostOverridesProduceDifferentCacheKeys() {
-        StorageConfig a =
-                new StorageConfig(GS_URI).setParameter(GoogleCloudStorageProvider.GCS_HOST, "http://localhost:4443");
-        StorageConfig b =
-                new StorageConfig(GS_URI).setParameter(GoogleCloudStorageProvider.GCS_HOST, "http://localhost:4444");
+    void differentEndpointsProduceDifferentCacheKeys() {
+        StorageConfig a = new StorageConfig(GS_URI)
+                .setParameter(GoogleCloudStorageProvider.GCS_ENDPOINT, URI.create("http://localhost:4443"));
+        StorageConfig b = new StorageConfig(GS_URI)
+                .setParameter(GoogleCloudStorageProvider.GCS_ENDPOINT, URI.create("http://localhost:4444"));
 
         assertThat(GoogleCloudStorageProvider.keyFor(a)).isNotEqualTo(GoogleCloudStorageProvider.keyFor(b));
     }

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageProviderTest.java
@@ -46,7 +46,7 @@ class GoogleCloudStorageProviderTest {
                         GoogleCloudStorageProvider.GCS_QUOTA_PROJECT_ID,
                         GoogleCloudStorageProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS,
                         GoogleCloudStorageProvider.GCS_USER_PROJECT,
-                        GoogleCloudStorageProvider.GCS_HOST);
+                        GoogleCloudStorageProvider.GCS_ENDPOINT);
 
         StorageConfig defaults = provider.getDefaultConfig();
         assertThat(defaults.getParameter(GoogleCloudStorageProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS))

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3StorageProvider.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3StorageProvider.java
@@ -136,6 +136,36 @@ public class S3StorageProvider extends AbstractStorageProvider {
             .defaultValue(false)
             .build();
 
+    /**
+     * A {@link StorageParameter} to override the S3 service endpoint, letting a canonical {@code s3://bucket/key} URI
+     * target a non-AWS S3-compatible service (MinIO, Ceph, Cloudflare R2, DigitalOcean Spaces, Wasabi, LocalStack)
+     * without encoding the service host into the URI.
+     *
+     * <p>When set, this takes precedence over any endpoint inferred from an {@code http(s)://host/bucket/key} base URI.
+     * Because custom endpoints almost always require path-style addressing, setting an endpoint defaults
+     * {@link #S3_FORCE_PATH_STYLE} to {@code true}; set {@code storage.s3.force-path-style} explicitly to override.
+     */
+    public static final StorageParameter<URI> S3_ENDPOINT = StorageParameter.builder()
+            .key("storage.s3.endpoint")
+            .title("Service endpoint")
+            .description("""
+                    Override the S3 service endpoint to let a canonical s3://bucket/key URI target a non-AWS \
+                    S3-compatible service (e.g. http://localhost:9000 for MinIO, https://<account>.r2.cloudflarestorage.com \
+                    for Cloudflare R2, https://<region>.digitaloceanspaces.com for DigitalOcean Spaces).
+
+                    The value is the service root (scheme, host, and optional port) without a bucket or key, \
+                    for example http://localhost:9000.
+
+                    When set, it takes precedence over any endpoint inferred from an http(s)://host/bucket/key base URI. \
+                    Leave it unset to use the default AWS endpoints for the configured region.
+
+                    Because custom endpoints almost always require path-style addressing, setting an endpoint \
+                    defaults storage.s3.force-path-style to true. Set storage.s3.force-path-style explicitly to override.
+                    """)
+            .type(URI.class)
+            .group(ID)
+            .build();
+
     /** Configuration parameter for AWS S3 region. */
     public static final StorageParameter<String> S3_REGION = StorageParameter.builder()
             .key("storage.s3.region")
@@ -271,6 +301,7 @@ public class S3StorageProvider extends AbstractStorageProvider {
     static final List<StorageParameter<?>> PARAMS = List.of(
             S3_FORCE_PATH_STYLE,
             S3_REQUESTER_PAYS,
+            S3_ENDPOINT,
             S3_REGION,
             S3_ANONYMOUS,
             S3_AWS_ACCESS_KEY_ID,
@@ -423,6 +454,17 @@ public class S3StorageProvider extends AbstractStorageProvider {
      *   <li>region parsed from the URI itself (e.g. {@code *.s3.us-west-2.amazonaws.com})
      *   <li>fallback to {@code us-east-1}
      * </ol>
+     *
+     * <p>Endpoint resolution order:
+     *
+     * <ol>
+     *   <li>explicit {@code storage.s3.endpoint} in {@code StorageConfig}
+     *   <li>endpoint parsed from an {@code http(s)://host/bucket/key} base URI
+     *   <li>none (default AWS endpoints for the resolved region)
+     * </ol>
+     *
+     * <p>{@code storage.s3.force-path-style} defaults to {@code true} whenever an endpoint override is in effect (from
+     * either source) and {@code false} for canonical AWS URIs; an explicit value always wins.
      */
     static S3ClientCache.Key keyFor(StorageConfig config) {
         URI uri = config.baseUri();
@@ -434,8 +476,8 @@ public class S3StorageProvider extends AbstractStorageProvider {
         Optional<String> accessKey = config.getParameter(S3_AWS_ACCESS_KEY_ID);
         Optional<String> secretKey = config.getParameter(S3_AWS_SECRET_ACCESS_KEY);
         Optional<String> profile = config.getParameter(S3_DEFAULT_CREDENTIALS_PROFILE);
-        boolean forcePathStyle = config.getParameter(S3_FORCE_PATH_STYLE).orElse(false);
-        Optional<URI> endpointOverride = s3Ref.endpointOverride();
+        Optional<URI> endpointOverride = config.getParameter(S3_ENDPOINT).or(s3Ref::endpointOverride);
+        boolean forcePathStyle = config.getParameter(S3_FORCE_PATH_STYLE).orElse(endpointOverride.isPresent());
         return new S3ClientCache.Key(
                 region, endpointOverride, anonymous, accessKey, secretKey, profile, forcePathStyle);
     }

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderConfigTest.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderConfigTest.java
@@ -75,6 +75,33 @@ class S3StorageProviderConfigTest {
     }
 
     @Test
+    void endpointOverride_explicitParameterUsedForCanonicalS3Uri() {
+        StorageConfig config = new StorageConfig("s3://my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("http://localhost:9000"));
+
+        assertThat(S3StorageProvider.keyFor(config).endpointOverride()).hasValue(URI.create("http://localhost:9000"));
+    }
+
+    @Test
+    void endpointOverride_explicitParameterWinsOverUriDerivedEndpoint() {
+        StorageConfig config = new StorageConfig("http://localhost:9000/my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("https://minio.example.com"));
+
+        assertThat(S3StorageProvider.keyFor(config).endpointOverride())
+                .hasValue(URI.create("https://minio.example.com"));
+    }
+
+    @Test
+    void differentEndpointsProduceDifferentCacheKeys() {
+        StorageConfig a = new StorageConfig("s3://my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("http://localhost:9000"));
+        StorageConfig b = new StorageConfig("s3://my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("http://localhost:9001"));
+
+        assertThat(S3StorageProvider.keyFor(a)).isNotEqualTo(S3StorageProvider.keyFor(b));
+    }
+
+    @Test
     void credentials_staticAccessAndSecretKeyAreCarriedOnTheKey() {
         StorageConfig config = new StorageConfig("s3://my-bucket/file.txt")
                 .setParameter(S3StorageProvider.S3_AWS_ACCESS_KEY_ID, "AKIA-static")
@@ -116,6 +143,30 @@ class S3StorageProviderConfigTest {
                 .setParameter(S3StorageProvider.S3_FORCE_PATH_STYLE, true);
 
         assertThat(S3StorageProvider.keyFor(config).forcePathStyle()).isTrue();
+    }
+
+    @Test
+    void forcePathStyle_defaultsToTrueWhenExplicitEndpointParamSet() {
+        StorageConfig config = new StorageConfig("s3://my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("http://localhost:9000"));
+
+        assertThat(S3StorageProvider.keyFor(config).forcePathStyle()).isTrue();
+    }
+
+    @Test
+    void forcePathStyle_defaultsToTrueForUriDerivedCustomEndpoint() {
+        StorageConfig config = new StorageConfig("http://localhost:9000/my-bucket/file.txt");
+
+        assertThat(S3StorageProvider.keyFor(config).forcePathStyle()).isTrue();
+    }
+
+    @Test
+    void forcePathStyle_explicitFalseOverridesEndpointDefault() {
+        StorageConfig config = new StorageConfig("s3://my-bucket/file.txt")
+                .setParameter(S3StorageProvider.S3_ENDPOINT, URI.create("http://localhost:9000"))
+                .setParameter(S3StorageProvider.S3_FORCE_PATH_STYLE, false);
+
+        assertThat(S3StorageProvider.keyFor(config).forcePathStyle()).isFalse();
     }
 
     @Test

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderTest.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageProviderTest.java
@@ -19,6 +19,7 @@ import static io.tileverse.storage.s3.S3StorageProvider.S3_ANONYMOUS;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_AWS_ACCESS_KEY_ID;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_AWS_SECRET_ACCESS_KEY;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_DEFAULT_CREDENTIALS_PROFILE;
+import static io.tileverse.storage.s3.S3StorageProvider.S3_ENDPOINT;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_FORCE_PATH_STYLE;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_REGION;
 import static io.tileverse.storage.s3.S3StorageProvider.S3_REQUESTER_PAYS;
@@ -84,6 +85,7 @@ class S3StorageProviderTest {
                 .isEqualTo(List.of(
                         S3_FORCE_PATH_STYLE,
                         S3_REQUESTER_PAYS,
+                        S3_ENDPOINT,
                         S3_REGION,
                         S3_ANONYMOUS,
                         S3_AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
  Adds a `storage.<backend>.endpoint` override to each cloud backend so an
  abstract/canonical URI can target a non-default or S3/GCS/Azure-compatible
  service, and aligns the three backends on one naming and typing convention.

  ## Changes

  - **`storage.s3.endpoint`** (new, `URI`) — lets a canonical `s3://bucket/key`
    URI target a non-AWS service (MinIO, Ceph, R2, Spaces, Wasabi, LocalStack)
    without encoding the host into the URI. An explicit endpoint wins over one
    parsed from an `http(s)://host/bucket/key` URI. `force-path-style` now
    defaults to `true` whenever an endpoint override is in effect (also fixing
    path-style not auto-enabling for URI-derived custom endpoints on the SPI
    path); an explicit value still wins.

  - **`storage.azure.endpoint`** (new, `URI`) — lets a short-form
    `az://account/container` URI target an emulator (Azurite), a sovereign cloud
    (Azure Government/China), or a custom domain instead of the hardcoded public
    `*.blob.core.windows.net` endpoint. The `https://` and `abfs(s)://` forms
    already encode the endpoint and are unaffected.

  - **`storage.gcs.endpoint`** (rename, `URI`) — replaces `storage.gcs.host`,
    which despite its name always held a full endpoint URL (the SDK's
    `setHost` expects a URI). The deprecated `storage.gcs.host` key is still
    accepted as a silent fallback.

  Credentials, region, and retry parameters are unchanged and orthogonal in all
  three backends.

  ## Notes

  - Endpoint resolution is a small, isolated change in each provider's cache-key
    derivation; clients with different endpoints already keyed distinct SDK
    client sets.
  - GCS source compatibility is preserved: the `GCS_HOST` constant remains,
    marked `@Deprecated`; only `storage.gcs.endpoint` is advertised through
    `buildParameters`.
  - Docs updated (storage overview, configure, use-each-backend, authenticate).

  ## Testing

  - TDD per backend; all module unit tests pass (S3 257, Azure 394, GCS 228).
  - `spotless` + `sortpom` clean.