### PR TITLE
feat(io): add allocation-backend SPI for ByteBufferPool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,9 @@
                 <excludes>
                   <exclude>**/logback-test.xml</exclude>
                   <exclude>logback-test.xml</exclude>
+                  <!-- Test-only ServiceLoader registrations must not leak into the test-jar: sibling modules
+                       consume tileverse-storage-core's test-jar and would otherwise discover test providers. -->
+                  <exclude>META-INF/services/io.tileverse.io.ByteBufferAllocator</exclude>
                 </excludes>
               </configuration>
             </execution>

--- a/tileverse-storage/core/src/main/java/io/tileverse/io/BuiltinByteBufferAllocator.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/io/BuiltinByteBufferAllocator.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.io;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Default {@link ByteBufferAllocator} used when no provider is registered. Direct buffers come from
+ * {@link ByteBuffer#allocateDirect(int)} and are released eagerly through {@link DirectByteBufferCleaner}; heap buffers
+ * come from {@link ByteBuffer#allocate(int)} and are left to the garbage collector. This reproduces the allocation
+ * behavior {@link ByteBufferPool} had before the allocation backend became pluggable.
+ */
+final class BuiltinByteBufferAllocator implements ByteBufferAllocator {
+
+    static final BuiltinByteBufferAllocator INSTANCE = new BuiltinByteBufferAllocator();
+
+    private BuiltinByteBufferAllocator() {
+        // singleton
+    }
+
+    @Override
+    public ByteBuffer allocateDirect(int capacity) {
+        return ByteBuffer.allocateDirect(capacity);
+    }
+
+    @Override
+    public ByteBuffer allocateHeap(int capacity) {
+        return ByteBuffer.allocate(capacity);
+    }
+
+    @Override
+    public void free(ByteBuffer buffer) {
+        if (buffer != null && buffer.isDirect()) {
+            DirectByteBufferCleaner.releaseDirectBuffer(buffer);
+        }
+    }
+}

--- a/tileverse-storage/core/src/main/java/io/tileverse/io/ByteBufferAllocator.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/io/ByteBufferAllocator.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.io;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Pluggable allocation backend for {@link ByteBufferPool}. A provider supplies the raw {@link ByteBuffer} instances the
+ * pool reuses and reclaims them when the pool evicts or clears them.
+ *
+ * <p><strong>Discovery:</strong> {@link ByteBufferPool#getDefault()} discovers a provider through
+ * {@link java.util.ServiceLoader}. When no provider is registered, the pool falls back to a built-in backend that
+ * allocates direct buffers with {@link ByteBuffer#allocateDirect(int)} and heap buffers with
+ * {@link ByteBuffer#allocate(int)}. Standalone tileverse on a Java 17 JVM therefore behaves exactly as it did before
+ * this interface existed. Pools constructed directly with {@link ByteBufferPool#ByteBufferPool(int, int, int)} use the
+ * built-in backend unless an allocator is passed explicitly.
+ *
+ * <p><strong>Allocate and free are a pair:</strong> a provider owns both the allocation and the release of every buffer
+ * it hands out. The pool calls {@link #free(ByteBuffer)} for every buffer it discards, so a provider must not rely on
+ * the pool to release memory by any other means. This pairing matters because the built-in backend releases direct
+ * buffers eagerly through {@code sun.misc.Unsafe.invokeCleaner}, which is valid only on a root direct buffer; a buffer
+ * obtained from a different mechanism (for example an FFM {@code MemorySegment} viewed as a {@code ByteBuffer}) would
+ * be rejected by that path. A provider that returns such buffers must therefore supply a matching
+ * {@link #free(ByteBuffer)} rather than inherit the built-in one.
+ *
+ * <p><strong>Thread safety:</strong> the pool calls these methods concurrently from multiple threads, so
+ * implementations must be thread-safe.
+ *
+ * <p>The interface uses only Java 17 types ({@link ByteBuffer}, {@code int}) so that tileverse-storage compiles to Java
+ * 17 bytecode while a provider compiled for a newer runtime can still supply buffers backed by a modern allocation
+ * mechanism, handed across the boundary as a plain {@link ByteBuffer}.
+ */
+public interface ByteBufferAllocator {
+
+    /**
+     * Allocates a new off-heap (direct) buffer with at least the given capacity.
+     *
+     * @param capacity the minimum capacity in bytes
+     * @return a direct {@link ByteBuffer} whose capacity is at least {@code capacity}
+     */
+    ByteBuffer allocateDirect(int capacity);
+
+    /**
+     * Allocates a new on-heap buffer with at least the given capacity.
+     *
+     * @param capacity the minimum capacity in bytes
+     * @return a heap {@link ByteBuffer} whose capacity is at least {@code capacity}
+     */
+    ByteBuffer allocateHeap(int capacity);
+
+    /**
+     * Releases a buffer previously produced by this allocator. The pool calls this when it evicts or clears a buffer.
+     * Implementations must tolerate both direct and heap buffers and must be safe to call once per buffer.
+     *
+     * @param buffer the buffer to release; never {@code null}
+     */
+    void free(ByteBuffer buffer);
+}

--- a/tileverse-storage/core/src/main/java/io/tileverse/io/ByteBufferPool.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/io/ByteBufferPool.java
@@ -18,6 +18,8 @@ package io.tileverse.io;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -80,9 +82,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ByteBufferPool {
 
-    /** Default singleton instance for convenient access. */
-    private static final ByteBufferPool DEFAULT_INSTANCE = new ByteBufferPool();
-
     /** Default maximum number of direct buffers to pool. */
     public static final int DEFAULT_MAX_DIRECT_BUFFERS = 32;
 
@@ -91,6 +90,13 @@ public class ByteBufferPool {
 
     /** Default block size for allocation alignment and pooling (8KB). */
     public static final int DEFAULT_BLOCK_SIZE = 8192;
+
+    /** Default singleton instance, backed by the discovered allocation provider (or the built-in backend). */
+    private static final ByteBufferPool DEFAULT_INSTANCE = new ByteBufferPool(
+            DEFAULT_MAX_DIRECT_BUFFERS, DEFAULT_MAX_HEAP_BUFFERS, DEFAULT_BLOCK_SIZE, discoverAllocator());
+
+    /** Allocation backend supplying and releasing the pooled buffers. */
+    private final ByteBufferAllocator allocator;
 
     /** Pool of direct ByteBuffers. */
     private final BufferQueue directBuffers;
@@ -107,7 +113,7 @@ public class ByteBufferPool {
     }
 
     /**
-     * Creates a new ByteBuffer pool with custom settings.
+     * Creates a new ByteBuffer pool with custom settings, using the built-in allocation backend.
      *
      * @param maxDirectBuffers maximum number of direct buffers to pool
      * @param maxHeapBuffers maximum number of heap buffers to pool
@@ -115,6 +121,24 @@ public class ByteBufferPool {
      * @throws IllegalArgumentException if any parameter is negative or zero
      */
     public ByteBufferPool(int maxDirectBuffers, int maxHeapBuffers, int blockSize) {
+        this(maxDirectBuffers, maxHeapBuffers, blockSize, BuiltinByteBufferAllocator.INSTANCE);
+    }
+
+    /**
+     * Creates a new ByteBuffer pool with custom settings and an explicit allocation backend.
+     *
+     * <p>The {@code allocator} supplies every pooled buffer and releases it when the pool evicts or clears it. Use this
+     * constructor to bind a pool to a specific backend; {@link #getDefault()} instead discovers one through
+     * {@link ServiceLoader}.
+     *
+     * @param maxDirectBuffers maximum number of direct buffers to pool
+     * @param maxHeapBuffers maximum number of heap buffers to pool
+     * @param blockSize block size for allocation alignment and minimum pooling threshold (bytes)
+     * @param allocator the allocation backend supplying and releasing pooled buffers
+     * @throws IllegalArgumentException if any numeric parameter is negative or zero
+     * @throws NullPointerException if {@code allocator} is null
+     */
+    public ByteBufferPool(int maxDirectBuffers, int maxHeapBuffers, int blockSize, ByteBufferAllocator allocator) {
         if (maxDirectBuffers <= 0) {
             throw new IllegalArgumentException("maxDirectBuffers must be positive: " + maxDirectBuffers);
         }
@@ -124,32 +148,27 @@ public class ByteBufferPool {
         if (blockSize <= 0) {
             throw new IllegalArgumentException("blockSize must be positive: " + blockSize);
         }
+        if (allocator == null) {
+            throw new NullPointerException("allocator cannot be null");
+        }
 
+        this.allocator = allocator;
         this.blockSize = blockSize;
 
-        // Initialize buffer queues
-        // Use Integer.MAX_VALUE for max individual buffer size effectively allowing any
-        // size
-        // to be pooled as long as it fits in the count limit
+        // Use Integer.MAX_VALUE for max individual buffer size, effectively allowing any
+        // size to be pooled as long as it fits in the count limit.
         this.directBuffers = new BufferQueue(
-                maxDirectBuffers,
-                blockSize,
-                Integer.MAX_VALUE,
-                ByteBuffer::allocateDirect,
-                DirectByteBufferCleaner::releaseDirectBuffer); // Use cleaner for direct buffers
+                maxDirectBuffers, blockSize, Integer.MAX_VALUE, allocator::allocateDirect, allocator::free);
 
-        this.heapBuffers = new BufferQueue(
-                maxHeapBuffers,
-                blockSize,
-                Integer.MAX_VALUE,
-                ByteBuffer::allocate,
-                b -> {}); // No-op for heap buffers (GC handles them)
+        this.heapBuffers =
+                new BufferQueue(maxHeapBuffers, blockSize, Integer.MAX_VALUE, allocator::allocateHeap, allocator::free);
 
         log.debug(
-                "Created ByteBufferPool: maxDirect={}, maxHeap={}, blockSize={}",
+                "Created ByteBufferPool: maxDirect={}, maxHeap={}, blockSize={}, allocator={}",
                 maxDirectBuffers,
                 maxHeapBuffers,
-                blockSize);
+                blockSize,
+                allocator.getClass().getName());
     }
 
     /**
@@ -162,6 +181,52 @@ public class ByteBufferPool {
      */
     public static ByteBufferPool getDefault() {
         return DEFAULT_INSTANCE;
+    }
+
+    /**
+     * Discovers the allocation backend for the default pool through {@link ServiceLoader}, falling back to the built-in
+     * backend when no provider is registered. A broken provider does not break the pool: discovery failures fall back
+     * to the built-in backend.
+     */
+    private static ByteBufferAllocator discoverAllocator() {
+        try {
+            List<ByteBufferAllocator> providers = new ArrayList<>();
+            for (ByteBufferAllocator provider : ServiceLoader.load(ByteBufferAllocator.class)) {
+                providers.add(provider);
+            }
+            return selectAllocator(providers);
+        } catch (RuntimeException | ServiceConfigurationError error) {
+            log.warn("Failed to load a ByteBufferAllocator provider; using the built-in backend.", error);
+            return BuiltinByteBufferAllocator.INSTANCE;
+        }
+    }
+
+    /**
+     * Picks the allocation backend from the discovered providers: the built-in backend when none are present, otherwise
+     * the first provider (warning when more than one is registered, since the choice is then ambiguous).
+     */
+    // visible for testing
+    static ByteBufferAllocator selectAllocator(List<ByteBufferAllocator> providers) {
+        if (providers.isEmpty()) {
+            return BuiltinByteBufferAllocator.INSTANCE;
+        }
+        ByteBufferAllocator selected = providers.get(0);
+        if (providers.size() > 1) {
+            log.warn(
+                    "Found {} ByteBufferAllocator providers; using {}. Register at most one.",
+                    providers.size(),
+                    selected.getClass().getName());
+        } else {
+            log.info(
+                    "Using ByteBufferAllocator provider {}", selected.getClass().getName());
+        }
+        return selected;
+    }
+
+    /** Returns the allocation backend supplying this pool's buffers. */
+    // visible for testing
+    ByteBufferAllocator allocator() {
+        return allocator;
     }
 
     /**
@@ -623,83 +688,6 @@ public class ByteBufferPool {
                 }
             }
             return low;
-        }
-    }
-
-    /**
-     * Reflective access to {@code sun.misc.Unsafe.invokeCleaner} (and a Java 8 fallback path) is the only way to
-     * release a direct {@link ByteBuffer}'s native memory eagerly without waiting for GC. The
-     * {@link java.lang.reflect.AccessibleObject#setAccessible(boolean)} calls below are required for that and are
-     * intentional; suppressing S3011 at the class level keeps the rest of the codebase honest about reflection usage.
-     */
-    @SuppressWarnings("java:S3011")
-    private static final class DirectByteBufferCleaner {
-        // internal unsafe instance for direct buffer cleanup
-        private static final Object UNSAFE;
-        private static final java.lang.reflect.Method INVOKE_CLEANER;
-
-        static {
-            Object unsafe = null;
-            java.lang.reflect.Method invokeCleaner = null;
-            try {
-                Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-                java.lang.reflect.Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
-                theUnsafe.setAccessible(true);
-                unsafe = theUnsafe.get(null);
-
-                // Available in Java 9+
-                try {
-                    invokeCleaner = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
-                } catch (NoSuchMethodException e) {
-                    // Fallback for Java 8 not needed since we are on Java 17, but good for safety
-                }
-            } catch (Exception e) {
-                log.warn("Could not get access to sun.misc.Unsafe. Direct buffer memory release will rely on GC.", e);
-            }
-            UNSAFE = unsafe;
-            INVOKE_CLEANER = invokeCleaner;
-        }
-
-        private DirectByteBufferCleaner() {
-            // no-op
-        }
-
-        /**
-         * Attempts to immediately release the memory of a direct ByteBuffer.
-         *
-         * @param buffer the buffer to release
-         */
-        static void releaseDirectBuffer(ByteBuffer buffer) {
-            if (buffer == null || !buffer.isDirect()) {
-                return;
-            }
-
-            if (UNSAFE != null && INVOKE_CLEANER != null) {
-                try {
-                    INVOKE_CLEANER.invoke(UNSAFE, buffer);
-                    return;
-                } catch (Exception e) {
-                    // log once or debug
-                    log.debug("Failed to invoke cleaner via Unsafe", e);
-                }
-            }
-
-            // Fallback to classic reflection (Java 8 style) or if Unsafe failed
-            // This will likely fail on Java 17+ without --add-opens, but we try anyway
-            try {
-                java.lang.reflect.Method cleanerMethod = buffer.getClass().getMethod("cleaner");
-                cleanerMethod.setAccessible(true);
-                Object cleaner = cleanerMethod.invoke(buffer);
-
-                if (cleaner != null) {
-                    java.lang.reflect.Method cleanMethod = cleaner.getClass().getMethod("clean");
-                    cleanMethod.setAccessible(true);
-                    cleanMethod.invoke(cleaner);
-                }
-            } catch (Exception e) {
-                // InaccessibleObjectException (Java 9+) or other errors
-                log.debug("Failed to release direct buffer memory via reflection", e);
-            }
         }
     }
 }

--- a/tileverse-storage/core/src/main/java/io/tileverse/io/DirectByteBufferCleaner.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/io/DirectByteBufferCleaner.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.io;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reflective access to {@code sun.misc.Unsafe.invokeCleaner} (and a Java 8 fallback path) is the only way to release a
+ * direct {@link ByteBuffer}'s native memory eagerly without waiting for GC. The
+ * {@link java.lang.reflect.AccessibleObject#setAccessible(boolean)} calls below are required for that and are
+ * intentional; suppressing S3011 at the class level keeps the rest of the codebase honest about reflection usage.
+ *
+ * <p>{@code invokeCleaner} is valid only on a <em>root</em> direct buffer (one that owns its native memory). It throws
+ * for slices, duplicates, and buffers viewing memory owned elsewhere, so this releaser must only be applied to buffers
+ * the built-in backend itself allocated.
+ */
+@Slf4j
+@SuppressWarnings("java:S3011")
+final class DirectByteBufferCleaner {
+
+    private static final Object UNSAFE;
+    private static final Method INVOKE_CLEANER;
+
+    static {
+        Object unsafe = null;
+        Method invokeCleaner = null;
+        try {
+            Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            unsafe = theUnsafe.get(null);
+            invokeCleaner = findInvokeCleaner(unsafeClass);
+        } catch (Exception e) {
+            log.warn("Could not get access to sun.misc.Unsafe. Direct buffer memory release will rely on GC.", e);
+        }
+        UNSAFE = unsafe;
+        INVOKE_CLEANER = invokeCleaner;
+    }
+
+    /** Resolves {@code Unsafe.invokeCleaner}, available since Java 9; returns null on a runtime that lacks it. */
+    private static Method findInvokeCleaner(Class<?> unsafeClass) {
+        try {
+            return unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
+        } catch (NoSuchMethodException e) {
+            // Java 8 lacks invokeCleaner; not reached on Java 17, handled for safety.
+            return null;
+        }
+    }
+
+    private DirectByteBufferCleaner() {
+        // no-op
+    }
+
+    /**
+     * Attempts to immediately release the memory of a direct ByteBuffer.
+     *
+     * @param buffer the buffer to release
+     */
+    static void releaseDirectBuffer(ByteBuffer buffer) {
+        if (buffer == null || !buffer.isDirect()) {
+            return;
+        }
+
+        if (UNSAFE != null && INVOKE_CLEANER != null) {
+            try {
+                INVOKE_CLEANER.invoke(UNSAFE, buffer);
+                return;
+            } catch (Exception e) {
+                log.debug("Failed to invoke cleaner via Unsafe", e);
+            }
+        }
+
+        // Fallback to classic reflection (Java 8 style) or if Unsafe failed.
+        // This will likely fail on Java 17+ without --add-opens, but we try anyway.
+        try {
+            Method cleanerMethod = buffer.getClass().getMethod("cleaner");
+            cleanerMethod.setAccessible(true);
+            Object cleaner = cleanerMethod.invoke(buffer);
+
+            if (cleaner != null) {
+                Method cleanMethod = cleaner.getClass().getMethod("clean");
+                cleanMethod.setAccessible(true);
+                cleanMethod.invoke(cleaner);
+            }
+        } catch (Exception e) {
+            // InaccessibleObjectException (Java 9+) or other errors
+            log.debug("Failed to release direct buffer memory via reflection", e);
+        }
+    }
+}

--- a/tileverse-storage/core/src/test/java/io/tileverse/io/ByteBufferAllocatorTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/io/ByteBufferAllocatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.tileverse.io.ByteBufferPool.PooledByteBuffer;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the pluggable allocation backend: provider selection, that an explicitly supplied
+ * {@link ByteBufferAllocator} receives all allocation and free calls, the built-in fallback, and {@code ServiceLoader}
+ * discovery on the default pool.
+ */
+class ByteBufferAllocatorTest {
+
+    @Test
+    void selectAllocator_noProviders_returnsBuiltin() {
+        ByteBufferAllocator selected = ByteBufferPool.selectAllocator(List.of());
+
+        assertThat(selected).isInstanceOf(BuiltinByteBufferAllocator.class);
+    }
+
+    @Test
+    void selectAllocator_singleProvider_returnsIt() {
+        CountingByteBufferAllocator provider = new CountingByteBufferAllocator();
+
+        assertThat(ByteBufferPool.selectAllocator(List.of(provider))).isSameAs(provider);
+    }
+
+    @Test
+    void selectAllocator_multipleProviders_returnsFirst() {
+        CountingByteBufferAllocator first = new CountingByteBufferAllocator();
+        CountingByteBufferAllocator second = new CountingByteBufferAllocator();
+
+        assertThat(ByteBufferPool.selectAllocator(List.of(first, second))).isSameAs(first);
+    }
+
+    @Test
+    void explicitAllocator_routesDirectAllocationAndFree() {
+        CountingByteBufferAllocator allocator = new CountingByteBufferAllocator();
+        ByteBufferPool pool = new ByteBufferPool(2, 2, 1024, allocator);
+
+        try (PooledByteBuffer pooled = pool.borrowDirect(1024)) {
+            assertThat(pooled.buffer().isDirect()).isTrue();
+        }
+
+        assertThat(allocator.directAllocations()).isEqualTo(1);
+        assertThat(allocator.frees()).isZero(); // returned to the pool, not freed
+
+        pool.clear(); // the pooled buffer is released through the allocator
+
+        assertThat(allocator.frees()).isEqualTo(1);
+    }
+
+    @Test
+    void explicitAllocator_routesHeapAllocation() {
+        CountingByteBufferAllocator allocator = new CountingByteBufferAllocator();
+        ByteBufferPool pool = new ByteBufferPool(2, 2, 1024, allocator);
+
+        try (PooledByteBuffer pooled = pool.borrowHeap(1024)) {
+            assertThat(pooled.buffer().isDirect()).isFalse();
+        }
+
+        assertThat(allocator.heapAllocations()).isEqualTo(1);
+    }
+
+    @Test
+    void builtinAllocator_allocatesBothKindsAndFreeToleratesEach() {
+        BuiltinByteBufferAllocator allocator = BuiltinByteBufferAllocator.INSTANCE;
+
+        ByteBuffer direct = allocator.allocateDirect(1024);
+        ByteBuffer heap = allocator.allocateHeap(1024);
+
+        assertThat(direct.isDirect()).isTrue();
+        assertThat(heap.isDirect()).isFalse();
+
+        allocator.free(heap); // no-op for heap, must not throw
+        allocator.free(direct); // releases native memory, must not throw
+    }
+
+    @Test
+    void getDefault_usesServiceLoaderProvider() {
+        // src/test/resources/META-INF/services registers CountingByteBufferAllocator as the sole provider
+        assertThat(ByteBufferPool.getDefault().allocator()).isInstanceOf(CountingByteBufferAllocator.class);
+    }
+}

--- a/tileverse-storage/core/src/test/java/io/tileverse/io/CountingByteBufferAllocator.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/io/CountingByteBufferAllocator.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.io;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test {@link ByteBufferAllocator} that counts calls and delegates allocation and release to the built-in backend, so
+ * pool behavior is identical to the default while the test can observe that allocations and frees were routed through
+ * the provider. Registered as a {@code ServiceLoader} provider via
+ * {@code META-INF/services/io.tileverse.io.ByteBufferAllocator} to exercise discovery on the default pool.
+ */
+public class CountingByteBufferAllocator implements ByteBufferAllocator {
+
+    private final AtomicInteger directAllocations = new AtomicInteger();
+    private final AtomicInteger heapAllocations = new AtomicInteger();
+    private final AtomicInteger frees = new AtomicInteger();
+
+    @Override
+    public ByteBuffer allocateDirect(int capacity) {
+        directAllocations.incrementAndGet();
+        return BuiltinByteBufferAllocator.INSTANCE.allocateDirect(capacity);
+    }
+
+    @Override
+    public ByteBuffer allocateHeap(int capacity) {
+        heapAllocations.incrementAndGet();
+        return BuiltinByteBufferAllocator.INSTANCE.allocateHeap(capacity);
+    }
+
+    @Override
+    public void free(ByteBuffer buffer) {
+        frees.incrementAndGet();
+        BuiltinByteBufferAllocator.INSTANCE.free(buffer);
+    }
+
+    int directAllocations() {
+        return directAllocations.get();
+    }
+
+    int heapAllocations() {
+        return heapAllocations.get();
+    }
+
+    int frees() {
+        return frees.get();
+    }
+}

--- a/tileverse-storage/core/src/test/resources/META-INF/services/io.tileverse.io.ByteBufferAllocator
+++ b/tileverse-storage/core/src/test/resources/META-INF/services/io.tileverse.io.ByteBufferAllocator
@@ -1,0 +1,1 @@
+io.tileverse.io.CountingByteBufferAllocator


### PR DESCRIPTION
Make `ByteBufferPool`'s allocation backend pluggable through a `ServiceLoader` SPI, `ByteBufferAllocator`, with `allocateDirect`/`allocateHeap`/`free`. The default pool discovers a provider via `getDefault()` and falls back to a built-in backend (direct via `allocateDirect` + `eager Unsafe.invokeCleaner` release, heap via allocate) when none is registered, so standalone use on Java 17 is unchanged. The public API stays the same.

allocate and free are a mandatory pair: a provider owns both the allocation and the release of every buffer it hands out, because the built-in release path uses `invokeCleaner`, valid only on a root direct buffer. A provider returning buffers from another mechanism must supply a matching free rather than inherit the built-in one.

The allocator feeds the existing `BufferQueue` factory/evictionListener seam. `DirectByteBufferCleaner` moves to its own file and is used by the built-in backend.

The test-only provider registration is excluded from the test-jar so sibling modules that consume tileverse-storage-core's test-jar do not discover it.
