### PR TITLE
fix(storage): honor storage.caching.blockaligned=false

### DIFF
--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/CachingProviderHelper.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/CachingProviderHelper.java
@@ -159,18 +159,17 @@ public final class CachingProviderHelper {
         if (!enableCaching) {
             return Optional.empty();
         }
-        Optional<Boolean> blockAligned = opts.getParameter(MEMORY_CACHE_BLOCK_ALIGNED);
-        Optional<Integer> blockSize = opts.getParameter(MEMORY_CACHE_BLOCK_SIZE);
+        final boolean blockAligned =
+                opts.getParameter(MEMORY_CACHE_BLOCK_ALIGNED).orElse(true);
+        final Optional<Integer> blockSize = opts.getParameter(MEMORY_CACHE_BLOCK_SIZE);
         return Optional.of(reader -> {
             Builder builder = CachingRangeReader.builder(reader);
-            if (blockAligned.isPresent()) {
-                if (blockSize.isPresent()) {
-                    builder.blockSize(blockSize.get());
-                } else {
-                    builder.withBlockAlignment();
-                }
-            } else {
+            if (!blockAligned) {
                 builder.withoutBlockAlignment();
+            } else if (blockSize.isPresent()) {
+                builder.blockSize(blockSize.get());
+            } else {
+                builder.withBlockAlignment();
             }
             return builder.build();
         });

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/cache/CachingProviderHelperTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/cache/CachingProviderHelperTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.tileverse.storage.RangeReader;
+import io.tileverse.storage.RangeReaderTestSupport;
+import io.tileverse.storage.StorageConfig;
+import io.tileverse.storage.spi.CachingProviderHelper;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that {@link CachingProviderHelper#cachingDecoratorFor(StorageConfig)} honors the value of
+ * {@code storage.caching.blockaligned}, not merely its presence. Drives the real decorator entry point and asserts the
+ * observable cache footprint of a 1-byte read. Lives in {@code io.tileverse.storage.cache} to read the package-private
+ * {@link CachingRangeReader#getEstimatedCacheSizeBytes()}.
+ */
+class CachingProviderHelperTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void blockalignedFalseDisablesAlignment() throws IOException {
+        Path testFile = writeRandomFile();
+
+        StorageConfig opts = new StorageConfig(testFile.toUri())
+                .setParameter(CachingProviderHelper.MEMORY_CACHE_ENABLED, true)
+                .setParameter(CachingProviderHelper.MEMORY_CACHE_BLOCK_ALIGNED, false);
+
+        try (RangeReader base = RangeReaderTestSupport.fileReader(testFile);
+                CachingRangeReader reader = (CachingRangeReader) CachingProviderHelper.cachingDecoratorFor(opts)
+                        .orElseThrow()
+                        .apply(base)) {
+
+            ByteBuffer out = ByteBuffer.allocate(16);
+            reader.readRange(2000, 1, out);
+
+            assertThat(reader.getEstimatedCacheSizeBytes()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void blockalignedDefaultStillAligns() throws IOException {
+        Path testFile = writeRandomFile();
+
+        StorageConfig opts =
+                new StorageConfig(testFile.toUri()).setParameter(CachingProviderHelper.MEMORY_CACHE_ENABLED, true);
+
+        try (RangeReader base = RangeReaderTestSupport.fileReader(testFile);
+                CachingRangeReader reader = (CachingRangeReader) CachingProviderHelper.cachingDecoratorFor(opts)
+                        .orElseThrow()
+                        .apply(base)) {
+
+            ByteBuffer out = ByteBuffer.allocate(16);
+            reader.readRange(2000, 1, out);
+
+            assertThat(reader.getEstimatedCacheSizeBytes()).isEqualTo(64L * 1024);
+        }
+    }
+
+    private Path writeRandomFile() throws IOException {
+        Path testFile = tempDir.resolve("test.bin");
+        byte[] data = new byte[100 * 1024];
+        new Random(42).nextBytes(data);
+        Files.write(testFile, data);
+        return testFile;
+    }
+}


### PR DESCRIPTION
cachingDecoratorFor branched on whether the blockaligned parameter was present, not its value, so blockaligned=false still block-aligned. With the parameter defaulting to true on the StorageFactory path, there was no property-driven way to turn alignment off.

Read the boolean value (orElse(true)) and branch on it. The default path is unchanged; only an explicit false now takes effect.

on-behalf-of: @camptocamp <info@camptocamp.com>