### PR TITLE
fix(storage): match DuckDB glob semantics for list patterns

### DIFF
--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/StoragePattern.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/StoragePattern.java
@@ -15,12 +15,9 @@
  */
 package io.tileverse.storage;
 
-import java.io.File;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import lombok.NonNull;
 
 /**
@@ -31,8 +28,8 @@ import lombok.NonNull;
  * <ul>
  *   <li><b>What to traverse</b>: the longest non-glob path prefix and whether to walk descendants or only immediate
  *       children.
- *   <li><b>What to match</b>: an optional {@link java.nio.file.PathMatcher} compiled from the glob portion that filters
- *       keys client-side after listing.
+ *   <li><b>What to match</b>: an optional predicate compiled from the glob portion that filters keys client-side after
+ *       listing.
  * </ul>
  *
  * <p>Examples (showing parsed prefix + walkDescendants + has-matcher):
@@ -42,7 +39,8 @@ import lombok.NonNull;
  * "data/"                 -> ("data/", false, no matcher)
  * "data/*.parquet"        -> ("data/", false, matcher)        // immediate children
  * "data/**"               -> ("data/", true,  matcher)        // walk all
- * "data/**\/*.parquet"    -> ("data/", true,  matcher)        // walk + filter
+ * "data/**\/*.parquet"    -> ("data/", true,  matcher)        // walk + filter, any depth incl. top level
+ * "**\/*.parquet"         -> ("",      true,  matcher)        // every .parquet anywhere, top level included
  * "data/{a,b}/file.txt"   -> ("data/", true,  matcher)        // depth-2; walk required to reach
  * "**.parquet"            -> ("",      true,  matcher)        // walk root
  * }</pre>
@@ -50,16 +48,27 @@ import lombok.NonNull;
  * <p>Rule for {@code walkDescendants}: true if the glob portion contains either {@code **} (cross-directory wildcard)
  * or {@code /} (any path separator implies the match targets nested levels).
  *
- * <p>The matcher is built from the full pattern (not just the glob suffix) using JDK glob syntax (see
- * {@link java.nio.file.FileSystem#getPathMatcher}), so it operates on the canonical full key form. On Windows the key
- * is normalized to the platform separator before matching.
+ * <p>The matcher is built from the full pattern (not just the glob suffix) and runs as a regex over the canonical
+ * {@code /}-separated key, so matching is OS-independent. The glob syntax follows DuckDB's convention rather than JDK
+ * glob:
  *
- * <p><b>Cross-platform glob portability:</b> glob compilation delegates to
- * {@code FileSystems.getDefault().getPathMatcher("glob:...")}, with {@code /} translated to the platform separator
- * before matching. The basic syntax ({@code *}, {@code **}, {@code ?}, character classes) is portable, but Windows'
- * glob compiler may differ in edge cases - brace expansion ({@code &#123;a,b&#125;}), negated character classes
- * ({@code [!abc]}), and escaping can behave differently from POSIX. If you need bit-identical cross-OS matching, stick
- * to {@code *}, {@code **}, {@code ?}, and unbracketed literals.
+ * <ul>
+ *   <li>{@code *} matches any run of characters within a single segment (does not cross {@code /}).
+ *   <li>{@code ?} matches exactly one character within a segment.
+ *   <li>{@code **} matches any run of characters including {@code /}.
+ *   <li>{@code **}{@code /} matches <b>zero or more</b> leading directories, so {@code **}{@code /*.parquet} also
+ *       matches a top-level {@code data.parquet} (this is where it diverges from JDK glob, which requires at least one
+ *       directory).
+ *   <li>{@code [abc]} and {@code [a-z]} match a single character in the set or range; a leading {@code !}
+ *       ({@code [!abc]}) negates it and never matches {@code /}. As in DuckDB, {@code ^} is an ordinary member, not a
+ *       negation marker.
+ *   <li>{@code /} is a literal separator.
+ * </ul>
+ *
+ * <p>{@code &#123;a,b&#125;} brace alternation is a tileverse/parquetry extension beyond DuckDB glob (parquetry emits
+ * {@code &#123;name.parquet&#125;} to force exact, prefix-free matching of a single file); the glob rules apply within
+ * each alternative. As in DuckDB, a metacharacter that cannot form a valid construct is treated as a literal: an
+ * unclosed {@code [} or a {@code &#123;} that opens no balanced group matches that character literally.
  *
  * @param prefix the literal storage-key prefix to seed listing from; never null, may be empty
  * @param walkDescendants when true, list all descendants of {@code prefix}; when false, list only immediate children
@@ -98,13 +107,128 @@ public record StoragePattern(String prefix, boolean walkDescendants, Optional<Pr
     }
 
     private static Predicate<String> globMatcher(String pattern) {
-        PathMatcher pm = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
-        return key -> {
-            if (key == null) {
-                return false;
-            }
-            Path p = Path.of(key.replace('/', File.separatorChar));
-            return pm.matches(p);
-        };
+        Pattern regex = Pattern.compile(globToRegex(pattern));
+        return key -> key != null && regex.matcher(key).matches();
     }
+
+    /**
+     * Translates a DuckDB-style glob into a regex anchored over a canonical {@code /}-separated storage key. The
+     * defining difference from JDK glob is that {@code **}{@code /} matches zero or more directories, so
+     * {@code **}{@code /*.parquet} also matches a top-level {@code data.parquet}.
+     *
+     * <ul>
+     *   <li>{@code *} matches any run of characters within a single segment (does not cross {@code /}).
+     *   <li>{@code ?} matches exactly one character within a segment.
+     *   <li>{@code **} matches any run of characters including {@code /}.
+     *   <li>{@code **}{@code /} matches zero or more leading directories.
+     *   <li>{@code [abc]}/{@code [a-z]} is a character class; a leading {@code !} negates it and excludes {@code /}.
+     *   <li>{@code &#123;a,b&#125;} is alternation (a tileverse extension beyond DuckDB), with the glob rules applied
+     *       within each alternative.
+     * </ul>
+     *
+     * <p>An unclosed {@code [} or {@code &#123;} is treated as a literal character, matching DuckDB.
+     */
+    static String globToRegex(String glob) {
+        StringBuilder regex = new StringBuilder("^");
+        appendGlob(glob, 0, glob.length(), regex);
+        return regex.append('$').toString();
+    }
+
+    private static void appendGlob(String glob, int from, int to, StringBuilder regex) {
+        int i = from;
+        while (i < to) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*' -> i = appendStar(glob, i, to, regex);
+                case '[' -> i = appendCharClass(glob, i, to, regex);
+                case '{' -> i = appendBrace(glob, i, regex);
+                case '?' -> {
+                    regex.append("[^/]");
+                    i++;
+                }
+                default -> {
+                    appendLiteral(c, regex);
+                    i++;
+                }
+            }
+        }
+    }
+
+    private static int appendStar(String glob, int start, int to, StringBuilder regex) {
+        boolean crossesDirectories = start + 1 < to && glob.charAt(start + 1) == '*';
+        if (!crossesDirectories) {
+            regex.append("[^/]*");
+            return start + 1;
+        }
+        boolean matchesLeadingDirectories = start + 2 < to && glob.charAt(start + 2) == '/';
+        if (matchesLeadingDirectories) {
+            regex.append("(?:.*/)?");
+            return start + 3;
+        }
+        regex.append(".*");
+        return start + 2;
+    }
+
+    /**
+     * Translates a {@code [...]} character class. DuckDB spells negation with a leading {@code !} only ({@code ^} is an
+     * ordinary member), and a negated class never matches the path separator.
+     */
+    private static int appendCharClass(String glob, int start, int to, StringBuilder regex) {
+        int contentStart = start + 1;
+        boolean negated = contentStart < to && glob.charAt(contentStart) == '!';
+        int firstMember = negated ? contentStart + 1 : contentStart;
+        int scanFrom = firstMember < to && glob.charAt(firstMember) == ']' ? firstMember + 1 : firstMember;
+        int close = glob.indexOf(']', scanFrom);
+        if (close < 0) {
+            appendLiteral('[', regex); // unclosed class: a lone '[' is a literal, as in DuckDB
+            return start + 1;
+        }
+        regex.append('[');
+        if (negated) {
+            regex.append('^');
+        }
+        for (int i = firstMember; i < close; i++) {
+            appendClassChar(glob.charAt(i), regex);
+        }
+        if (negated) {
+            regex.append('/');
+        }
+        regex.append(']');
+        return close + 1;
+    }
+
+    private static void appendClassChar(char c, StringBuilder regex) {
+        if (c == '\\' || c == ']' || c == '[' || c == '^') {
+            regex.append('\\');
+        }
+        regex.append(c);
+    }
+
+    private static int appendBrace(String glob, int start, StringBuilder regex) {
+        int close = glob.indexOf('}', start);
+        if (close < 0) {
+            appendLiteral('{', regex); // no closing '}': a lone '{' is a literal, as in DuckDB
+            return start + 1;
+        }
+        String[] alternatives = glob.substring(start + 1, close).split(",");
+        regex.append("(?:");
+        for (int k = 0; k < alternatives.length; k++) {
+            if (k > 0) {
+                regex.append('|');
+            }
+            String alternative = alternatives[k];
+            appendGlob(alternative, 0, alternative.length(), regex);
+        }
+        regex.append(')');
+        return close + 1;
+    }
+
+    private static void appendLiteral(char c, StringBuilder regex) {
+        if (REGEX_METACHARACTERS.indexOf(c) >= 0) {
+            regex.append('\\');
+        }
+        regex.append(c);
+    }
+
+    private static final String REGEX_METACHARACTERS = "\\.[]{}()+-^$|";
 }

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/StoragePatternTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/StoragePatternTest.java
@@ -18,7 +18,21 @@ package io.tileverse.storage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class StoragePatternTest {
 
@@ -89,9 +103,111 @@ class StoragePatternTest {
                 .isTrue();
         assertThat(p.matcher().get().test("data/release=2024-01/theme=transportation/file.parquet"))
                 .isFalse();
-        assertThat(p.matcher().get().test("data/theme=buildings/file.parquet")).isFalse();
+        // Ant/DuckDB semantics: **/ matches zero directories, so the literal segment may sit directly under data/.
+        assertThat(p.matcher().get().test("data/theme=buildings/file.parquet")).isTrue();
         assertThat(p.matcher().get().test("data/release=2024-01/theme=buildings/sub/file.parquet"))
                 .isFalse();
+    }
+
+    @Test
+    void leadingDoubleStarSlashMatchesTopLevelAndAnyDepth() {
+        // The conventional "every .parquet anywhere, including top level" pattern.
+        StoragePattern p = StoragePattern.parse("**/*.parquet");
+        assertThat(p.prefix()).isEmpty();
+        assertThat(p.walkDescendants()).isTrue();
+        assertThat(p.matcher().get().test("data.parquet")).isTrue();
+        assertThat(p.matcher().get().test("a/data.parquet")).isTrue();
+        assertThat(p.matcher().get().test("a/b/data.parquet")).isTrue();
+        assertThat(p.matcher().get().test("data.txt")).isFalse();
+    }
+
+    @Test
+    void prefixedDoubleStarSlashMatchesZeroOrMoreDirs() {
+        StoragePattern p = StoragePattern.parse("data/**/*.parquet");
+        assertThat(p.prefix()).isEqualTo("data/");
+        assertThat(p.walkDescendants()).isTrue();
+        assertThat(p.matcher().get().test("data/x.parquet")).isTrue(); // zero intermediate dirs
+        assertThat(p.matcher().get().test("data/a/b/x.parquet")).isTrue();
+        assertThat(p.matcher().get().test("other/x.parquet")).isFalse();
+    }
+
+    @Test
+    void braceMatchesSingleFileExactly() {
+        // parquetry emits {name.parquet} for a single-file URI to force exact matching instead of prefix matching.
+        StoragePattern p = StoragePattern.parse("{example.parquet}");
+        assertThat(p.prefix()).isEmpty();
+        assertThat(p.matcher()).isPresent();
+        assertThat(p.matcher().get().test("example.parquet")).isTrue();
+        assertThat(p.matcher().get().test("example.parquet.bak")).isFalse();
+        assertThat(p.matcher().get().test("sub/example.parquet")).isFalse();
+    }
+
+    @Test
+    void braceAlternationRecursesGlobRules() {
+        StoragePattern p = StoragePattern.parse("{*.parquet,**/*.parquet}");
+        assertThat(p.matcher()).isPresent();
+        assertThat(p.matcher().get().test("data.parquet")).isTrue();
+        assertThat(p.matcher().get().test("year=2024/data.parquet")).isTrue();
+        assertThat(p.matcher().get().test("data.csv")).isFalse();
+    }
+
+    @Test
+    void characterClassMatchesOneOfTheSet() {
+        StoragePattern p = StoragePattern.parse("part[12].txt");
+        assertThat(p.matcher()).isPresent();
+        assertThat(p.matcher().get().test("part1.txt")).isTrue();
+        assertThat(p.matcher().get().test("part2.txt")).isTrue();
+        assertThat(p.matcher().get().test("partX.txt")).isFalse();
+    }
+
+    @Test
+    void characterClassRange() {
+        StoragePattern p = StoragePattern.parse("f[A-C].txt");
+        assertThat(p.matcher().get().test("fB.txt")).isTrue();
+        assertThat(p.matcher().get().test("fD.txt")).isFalse();
+    }
+
+    @Test
+    void negatedCharacterClassUsesBangAndNeverCrossesSlash() {
+        StoragePattern p = StoragePattern.parse("a[!z]b.txt");
+        assertThat(p.matcher().get().test("axb.txt")).isTrue();
+        assertThat(p.matcher().get().test("azb.txt")).isFalse();
+        // DuckDB: a negated class never matches the path separator.
+        assertThat(p.matcher().get().test("a/b.txt")).isFalse();
+    }
+
+    @Test
+    void caretInsideClassIsLiteralNotNegation() {
+        // DuckDB spells negation with '!' only; '^' is an ordinary set member.
+        StoragePattern p = StoragePattern.parse("x[^y].txt");
+        assertThat(p.matcher().get().test("x^.txt")).isTrue();
+        assertThat(p.matcher().get().test("xy.txt")).isTrue();
+        assertThat(p.matcher().get().test("xz.txt")).isFalse();
+    }
+
+    @Test
+    void unclosedCharacterClassIsTreatedAsLiteral() {
+        // DuckDB treats an unclosed '[' as a literal character (verified against the duckdb binary).
+        StoragePattern p = StoragePattern.parse("lt[1.txt");
+        assertThat(p.matcher().get().test("lt[1.txt")).isTrue();
+        assertThat(p.matcher().get().test("lt1.txt")).isFalse();
+    }
+
+    @Test
+    void loneBraceIsTreatedAsLiteral() {
+        // Braces are a tileverse extension; a '{' that opens no balanced group falls back to DuckDB's literal
+        // treatment.
+        StoragePattern p = StoragePattern.parse("br{a.txt");
+        assertThat(p.matcher().get().test("br{a.txt")).isTrue();
+        assertThat(p.matcher().get().test("bra.txt")).isFalse();
+    }
+
+    @Test
+    void trailingCommaInBraceDoesNotMatchEmpty() {
+        StoragePattern p = StoragePattern.parse("file{a,b,}.txt");
+        assertThat(p.matcher().get().test("filea.txt")).isTrue();
+        assertThat(p.matcher().get().test("fileb.txt")).isTrue();
+        assertThat(p.matcher().get().test("file.txt")).isFalse();
     }
 
     @Test
@@ -148,5 +264,50 @@ class StoragePatternTest {
     @Test
     void nullPatternIsRejected() {
         assertThatNullPointerException().isThrownBy(() -> StoragePattern.parse(null));
+    }
+
+    /**
+     * Replays the shared golden table ({@code glob-cases.tsv}) that pins the matcher to DuckDB glob semantics. The
+     * {@code duckdb}-sourced rows are reproducible with {@code verify-glob-cases.sh}; keep the table identical in
+     * parquetry's copy of the translator.
+     */
+    @Nested
+    class GlobToRegex {
+
+        @ParameterizedTest(name = "[{3}] {0} ~ {1} -> {2}")
+        @MethodSource("io.tileverse.storage.StoragePatternTest#goldenCases")
+        void matchesGoldenTable(String glob, String key, boolean expected, String source) {
+            boolean actual = Pattern.compile(StoragePattern.globToRegex(glob))
+                    .matcher(key)
+                    .matches();
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    static Stream<Arguments> goldenCases() {
+        return readGoldenTable().stream();
+    }
+
+    private static List<Arguments> readGoldenTable() {
+        String resource = "glob-cases.tsv";
+        try (InputStream in = StoragePatternTest.class.getResourceAsStream(resource);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            List<Arguments> rows = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] columns = line.split("\t");
+                String glob = columns[0];
+                String key = columns[1];
+                boolean expected = Boolean.parseBoolean(columns[2]);
+                String source = columns[3];
+                rows.add(Arguments.of(glob, key, expected, source));
+            }
+            return rows;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/tileverse-storage/core/src/test/resources/io/tileverse/storage/glob-cases.tsv
+++ b/tileverse-storage/core/src/test/resources/io/tileverse/storage/glob-cases.tsv
@@ -1,0 +1,42 @@
+# Golden glob-matching table: the shared cross-repo contract for DuckDB glob parity.
+#
+# Tab-separated columns: glob <TAB> key <TAB> expected <TAB> source
+#   source=duckdb     expected captured from the real duckdb binary; StoragePattern must match it.
+#   source=tileverse  brace alternation, a tileverse/parquetry extension DuckDB lacks; expected is our own spec.
+#
+# Replayed by StoragePatternTest.GlobToRegex. Keep this file identical in parquetry's copy of the translator.
+# Re-derive/verify the duckdb rows with verify-glob-cases.sh (needs the duckdb CLI on PATH).
+#
+# glob	key	expected	source
+**/*.parquet	data.parquet	true	duckdb
+**/*.parquet	year=2024/data.parquet	true	duckdb
+**/*.parquet	a/b/c/data.parquet	true	duckdb
+*.parquet	data.parquet	true	duckdb
+*.parquet	year=2024/data.parquet	false	duckdb
+data/*.parquet	data/file.parquet	true	duckdb
+data/*.parquet	data/sub/file.parquet	false	duckdb
+data/**	data/sub/f.parquet	true	duckdb
+data/**/theme=buildings/f.parquet	data/theme=buildings/f.parquet	true	duckdb
+data/**/theme=buildings/f.parquet	data/r=1/x=2/theme=buildings/f.parquet	true	duckdb
+data/**/theme=buildings/f.parquet	data/r=1/theme=buildings/sub/f.parquet	false	duckdb
+f[A-C].txt	fB.txt	true	duckdb
+f[A-C].txt	fD.txt	false	duckdb
+part[12].txt	part1.txt	true	duckdb
+part[12].txt	partX.txt	false	duckdb
+part[!12].txt	partX.txt	true	duckdb
+part[!12].txt	part1.txt	false	duckdb
+part[^12].txt	part1.txt	true	duckdb
+part[^12].txt	partX.txt	false	duckdb
+a[!z]b.txt	axb.txt	true	duckdb
+a[!z]b.txt	a/b.txt	false	duckdb
+lt[1.txt	lt[1.txt	true	duckdb
+lt[1.txt	lt1.txt	false	duckdb
+br{a.txt	br{a.txt	true	duckdb
+br{a.txt	bra.txt	false	duckdb
+{example.parquet}	example.parquet	true	tileverse
+{example.parquet}	example.parquet.bak	false	tileverse
+{example.parquet}	sub/example.parquet	false	tileverse
+{*.parquet,**/*.parquet}	data.parquet	true	tileverse
+{*.parquet,**/*.parquet}	year=2024/data.parquet	true	tileverse
+file{a,b,}.txt	filea.txt	true	tileverse
+file{a,b,}.txt	file.txt	false	tileverse

--- a/tileverse-storage/core/src/test/resources/io/tileverse/storage/verify-glob-cases.sh
+++ b/tileverse-storage/core/src/test/resources/io/tileverse/storage/verify-glob-cases.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Verify the source=duckdb rows of glob-cases.tsv against the real duckdb CLI.
+#
+# This is the provenance tool for the golden table: it proves that every
+# duckdb-sourced expected value reflects actual DuckDB glob behavior. Run it when
+# adding duckdb rows or after a DuckDB upgrade; it is not part of the build (the
+# replay test in StoragePatternTest is hermetic and needs no duckdb).
+#
+# For each row it materializes ONLY that key in a fresh temp dir, asks duckdb, and
+# compares. Per-row isolation avoids one row's files polluting another's glob.
+# Exits non-zero if any duckdb row disagrees with the binary.
+#
+# Usage: ./verify-glob-cases.sh
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+table="$here/glob-cases.tsv"
+
+command -v duckdb >/dev/null 2>&1 || {
+    echo "duckdb CLI not found on PATH" >&2
+    exit 2
+}
+
+fail=0
+while IFS=$'\t' read -r glob key expected source; do
+    [ -z "${glob:-}" ] && continue
+    case "$glob" in \#*) continue ;; esac
+    [ "${source:-}" = "duckdb" ] || continue
+
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/$(dirname "$key")" 2>/dev/null
+    : > "$dir/$key"
+    count="$(duckdb -noheader -list -c "SELECT count(*) FROM glob('$dir/$glob') WHERE file = '$dir/$key';" 2>/dev/null)"
+    actual=$([ "$count" = "1" ] && echo true || echo false)
+    rm -rf "$dir"
+
+    if [ "$actual" = "$expected" ]; then
+        flag=OK
+    else
+        flag="**MISMATCH**"
+        fail=1
+    fi
+    printf '%-40s %-38s expected=%-5s duckdb=%-5s %s\n' "$glob" "$key" "$expected" "$actual" "$flag"
+done < "$table"
+
+exit $fail


### PR DESCRIPTION
StoragePattern compiled list globs through the JDK PathMatcher, whose `**/` requires at least one intermediate directory. The conventional `**/*.parquet` therefore dropped top-level files, the common flat-directory case.

Replace it with a glob-to-regex translation over the canonical `/`-separated key, matching DuckDB:
- `**/` matches zero or more directories (top-level included)
- `[abc]` / `[a-z]` / `[!abc]` character classes; '`!`' negation only, and a negated class never matches '`/`'
- `{a,b}` alternation, kept as a tileverse/parquetry extension
- an unclosed '`[`' or '`{`' is treated as a literal character, as in DuckDB

Matching no longer depends on the platform separator.

A shared golden table (glob-cases.tsv) replayed by the tests pins the matcher to DuckDB; verify-glob-cases.sh re-derives its duckdb rows from the real binary. Keep the table identical in parquetry's copy.

on-behalf-of: @multiversio <info@multivers.io>