### PR TITLE
build(deps): migrate Testcontainers 1.21.4 -> 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <junit.version>6.0.3</junit.version>
     <logback.version>1.5.18</logback.version>
     <mockito.version>5.18.0</mockito.version>
-    <testcontainers.version>1.21.4</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <wiremock.version>3.13.1</wiremock.version>
     <surefire.skip>false</surefire.skip>
     <failsafe.skip>false</failsafe.skip>
@@ -226,7 +226,7 @@
       <dependency>
         <groupId>io.aiven</groupId>
         <artifactId>testcontainers-fake-gcs-server</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/tileverse-storage/all/pom.xml
+++ b/tileverse-storage/all/pom.xml
@@ -35,22 +35,22 @@
     <!-- TestContainers for integration tests -->
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>localstack</artifactId>
+      <artifactId>testcontainers-localstack</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>minio</artifactId>
+      <artifactId>testcontainers-minio</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>azure</artifactId>
+      <artifactId>testcontainers-azure</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tileverse-storage/azure/pom.xml
+++ b/tileverse-storage/azure/pom.xml
@@ -46,12 +46,12 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>azure</artifactId>
+      <artifactId>testcontainers-azure</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tileverse-storage/core/pom.xml
+++ b/tileverse-storage/core/pom.xml
@@ -22,7 +22,7 @@
     <!-- TestContainers for integration tests -->
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/tck/StorageTCK.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/tck/StorageTCK.java
@@ -16,8 +16,8 @@
 package io.tileverse.storage.tck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.tileverse.storage.CopyOptions;
@@ -381,8 +381,7 @@ public abstract class StorageTCK {
     @Test
     void deleteIsIdempotentOnMissingKey() {
         requireWrites();
-        storage.delete("never-existed"); // no exception
-        assertTrue(true);
+        assertThatNoException().isThrownBy(() -> storage.delete("never-existed"));
     }
 
     @Test

--- a/tileverse-storage/gcs/pom.xml
+++ b/tileverse-storage/gcs/pom.xml
@@ -29,7 +29,7 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tileverse-storage/s3/pom.xml
+++ b/tileverse-storage/s3/pom.xml
@@ -52,17 +52,17 @@
     <!-- TestContainers for integration tests -->
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>localstack</artifactId>
+      <artifactId>testcontainers-localstack</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>minio</artifactId>
+      <artifactId>testcontainers-minio</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderLocalStackIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderLocalStackIT.java
@@ -25,9 +25,9 @@ import java.net.URI;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -55,9 +55,8 @@ class S3RangeReaderLocalStackIT extends AbstractRangeReaderIT {
 
     @Container
     @SuppressWarnings("resource")
-    static LocalStackContainer localstack = new LocalStackContainer(
-                    DockerImageName.parse("localstack/localstack:3.2.0"))
-            .withServices(LocalStackContainer.Service.S3);
+    static LocalStackContainer localstack =
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices("s3");
 
     @BeforeAll
     static void setupS3() throws IOException {

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
@@ -33,10 +33,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -73,7 +72,7 @@ class S3RequesterPaysIT {
     @Container
     @SuppressWarnings("resource")
     private static LocalStackContainer localstack =
-            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices(Service.S3);
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices("s3");
 
     private static final String REQUEST_PAYER_HEADER = "x-amz-request-payer";
 

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageFactoryIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageFactoryIT.java
@@ -15,8 +15,8 @@
  */
 package io.tileverse.storage.s3;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeNoException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 import io.tileverse.storage.StorageConfig;
 import io.tileverse.storage.StorageFactory;
@@ -146,7 +146,7 @@ class S3StorageFactoryIT {
         try {
             defaultCredentialsProvider.resolveCredentials();
         } catch (SdkClientException noCredentials) {
-            assumeNoException("Test requires AWS credentials", noCredentials);
+            abort("Test requires AWS credentials: " + noCredentials.getMessage());
         }
     }
 
@@ -160,7 +160,7 @@ class S3StorageFactoryIT {
         // would race with sibling ITs over ambient AWS credentials in sys props.
         StorageConfig config = new StorageConfig(s3Uri);
         StorageProvider provider = StorageFactory.findProvider(config);
-        assertNotNull("Should resolve a provider for " + description, provider);
+        assertThat(provider).as("Should resolve a provider for " + description).isNotNull();
         // Either the S3 provider or (for ambiguous custom-domain HTTPS URLs that don't HEAD-probe
         // as S3 in this environment) the generic HTTP provider is acceptable - both prove the URL
         // parser accepted the input.

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageLocalStackIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3StorageLocalStackIT.java
@@ -33,10 +33,9 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -61,7 +60,7 @@ class S3StorageLocalStackIT extends StorageTCK {
     @Container
     @SuppressWarnings("resource")
     private static LocalStackContainer localstack =
-            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices(Service.S3);
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.2.0")).withServices("s3");
 
     private static S3ClientCache cache;
     private String bucket;

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3VersioningIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3VersioningIT.java
@@ -24,10 +24,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -46,14 +45,14 @@ class S3VersioningIT {
 
     @Container
     static final LocalStackContainer LOCALSTACK =
-            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.7")).withServices(Service.S3);
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.7")).withServices("s3");
 
     private S3Client adminClient;
 
     @BeforeAll
     void provisionVersionedBucket() {
         adminClient = S3Client.builder()
-                .endpointOverride(LOCALSTACK.getEndpointOverride(Service.S3))
+                .endpointOverride(LOCALSTACK.getEndpoint())
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey())))
                 .region(Region.of(LOCALSTACK.getRegion()))


### PR DESCRIPTION
Testcontainers 2.0 prefixes module artifacts with testcontainers-, relocates LocalStackContainer, and removes JUnit 4 support.

- bump testcontainers-bom to 2.0.5 and io.aiven testcontainers-fake-gcs-server 0.2.0 -> 0.3.0 (its 2.0-compatible line)
- rename module deps junit-jupiter/localstack/minio/azure to their testcontainers-<module> coordinates
- LocalStack: move to org.testcontainers.localstack.LocalStackContainer with withServices("s3") and getEndpoint(); the Service enum and getEndpointOverride(Service) are gone
- replace the JUnit 4 API (org.junit.Assert/Assume) that 1.x leaked onto the test classpath with AssertJ and JUnit 5 Assumptions

on-behalf-of: @multiversio <info@multivers.io>