### PR TITLE
test(storage): point online S3 ITs at a stable public bucket

### DIFF
--- a/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryIT.java
+++ b/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryIT.java
@@ -293,11 +293,27 @@ class StorageFactoryIT {
     }
 
     /**
-     * Single-arg overload aimed at public-bucket URLs (Overture Maps and similar). Sets {@code S3_ANONYMOUS=true} so
-     * the SDK does not consult the default credential chain, which would fail on a clean CI box.
+     * Single-arg overload aimed at public-bucket URLs. Sets {@code S3_ANONYMOUS=true} so the SDK does not consult the
+     * default credential chain, which would fail on a clean CI box.
      */
     static RangeReader testS3(String uri) throws IOException {
-        return testS3(URI.create(uri), null, null, true);
+        return testS3(uri, null);
+    }
+
+    /**
+     * Public-bucket overload for URL forms without a region (e.g. {@code s3://bucket/key} or the legacy global
+     * endpoint). The provider contract requires the region from configuration or the AWS environment in that case;
+     * supplying it here keeps the test independent of the local AWS setup.
+     */
+    static RangeReader testS3(String uri, String region) throws IOException {
+        URI s3URI = URI.create(uri);
+        testFindBestProvider(s3URI, S3StorageProvider.class);
+        StorageConfig config = new StorageConfig(s3URI);
+        config.setParameter(S3StorageProvider.S3_ANONYMOUS, true);
+        if (region != null) {
+            config.setParameter(S3StorageProvider.S3_REGION, region);
+        }
+        return testCreate(config);
     }
 
     static RangeReader testS3(final URI s3URI, String accessKey, String secretKey) throws IOException {

--- a/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryOnlineIT.java
+++ b/tileverse-storage/all/src/test/java/io/tileverse/storage/StorageFactoryOnlineIT.java
@@ -37,6 +37,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class StorageFactoryOnlineIT {
 
+    /**
+     * Anonymous-read object in the AWS Open Data sentinel-cogs bucket, unchanged since 2020. Overture Maps buckets are
+     * unsuitable here: their release objects expire 60 days after publication (rule-id "release data 60 day
+     * retention"), which is how the previous URLs went dark.
+     */
+    private static final String S3_BUCKET = "sentinel-cogs";
+
+    private static final String S3_REGION = "us-west-2";
+    private static final String S3_KEY = "sentinel-s2-l2a-cogs/33/T/UL/2020/6/S2A_33TUL_20200604_0_L2A/B01.tif";
+
     @Test
     @DisplayName("HTTPS URL that doesn't match a cloud provider uses HttpRangeReader")
     void plainHttpsUrl() throws IOException {
@@ -87,43 +97,45 @@ class StorageFactoryOnlineIT {
     @Test
     @DisplayName("S3 https:// virtual hosted-style (legacy format) URL uses S3RangeReaderProvider")
     void s3HttpsUrlVirtualHostedStyle() throws IOException {
-        testS3("https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2025-08-20/base.pmtiles");
+        // the legacy global endpoint has no region in the URL; the provider requires it from configuration
+        testS3("https://" + S3_BUCKET + ".s3.amazonaws.com/" + S3_KEY, S3_REGION);
     }
 
     @Test
     @DisplayName("S3 https:// virtual hosted-style with region URL uses S3RangeReaderProvider")
     void s3HttpsUrlVirtualHostedWithRegion() throws IOException {
-        testS3("https://overturemaps-tiles-us-west-2-beta.s3.us-west-2.amazonaws.com/2025-08-20/base.pmtiles");
+        testS3("https://" + S3_BUCKET + ".s3." + S3_REGION + ".amazonaws.com/" + S3_KEY);
     }
 
     @Test
     @DisplayName("S3 https:// path-style URL with region uses S3RangeReaderProvider")
     void s3PathStyleUrlWithRegion() throws IOException {
-        testS3("https://s3.us-west-2.amazonaws.com/overturemaps-tiles-us-west-2-beta/2025-08-20/base.pmtiles");
+        testS3("https://s3." + S3_REGION + ".amazonaws.com/" + S3_BUCKET + "/" + S3_KEY);
     }
 
     @Test
     @DisplayName("S3 s3:// URL uses S3RangeReaderProvider")
     void s3Url() throws IOException {
-        testS3("s3://overturemaps-tiles-us-west-2-beta/2025-08-20/base.pmtiles");
+        // s3:// URIs have no region; the provider requires it from configuration or the AWS environment
+        testS3("s3://" + S3_BUCKET + "/" + S3_KEY, S3_REGION);
     }
 
     @Test
     @DisplayName("S3 https:// virtual hosted-style (legacy format) URL with forced HTTP provider uses HttpRangeReader")
     void s3LegacyVirtualHostedStyleUrlWithForcedHttpProvider() throws IOException {
-        testForceHttp("https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2025-08-20/base.pmtiles");
+        testForceHttp("https://" + S3_BUCKET + ".s3.amazonaws.com/" + S3_KEY);
     }
 
     @Test
     @DisplayName("S3 https:// virtual hosted-style URL with forced HTTP provider uses HttpRangeReader")
     void s3VirtualHostedStyleUrlWithForcedHttpProvider() throws IOException {
-        testForceHttp("https://overturemaps-tiles-us-west-2-beta.s3.us-west-2.amazonaws.com/2025-08-20/base.pmtiles");
+        testForceHttp("https://" + S3_BUCKET + ".s3." + S3_REGION + ".amazonaws.com/" + S3_KEY);
     }
 
     @Test
     @DisplayName("S3 https:// path-style URL with forced HTTP provider uses HttpRangeReader")
     void s3PathStyleUrlWithForcedHttpProvider() throws IOException {
-        testForceHttp("https://s3.us-west-2.amazonaws.com/overturemaps-tiles-us-west-2-beta/2025-08-20/base.pmtiles");
+        testForceHttp("https://s3." + S3_REGION + ".amazonaws.com/" + S3_BUCKET + "/" + S3_KEY);
     }
 
     /**


### PR DESCRIPTION
The Overture Maps tiles bucket the ITs read from no longer allows anonymous access, and all Overture release objects expire 60 days after publication, meaning any hardcoded URL there rots. Use the AWS Open Data sentinel-cogs bucket instead, whose objects are unchanged since 2020.

The region-less URL forms (s3:// and the legacy global endpoint) only worked before because the old bucket name embedded "us-west-2" and the URL parser picked it up. The new bucket name has no region hint; supply the region through the storage.s3.region parameter, which is the documented contract for region-less URIs.

on-behalf-of: @multiversio <info@multivers.io>