### PR TITLE
fix(storage): make block-aligned caching opt-in

### DIFF
--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/AbstractStorageProvider.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/AbstractStorageProvider.java
@@ -34,8 +34,9 @@ public abstract class AbstractStorageProvider implements StorageProvider {
 
     /**
      * Re-export of {@link CachingProviderHelper#MEMORY_CACHE_BLOCK_ALIGNED}. When enabled, all read requests are
-     * aligned to the configured block boundaries before consulting the {@link CachingRangeReader} cache. Only
-     * meaningful when {@link #MEMORY_CACHE_ENABLED} is true.
+     * aligned to the configured block boundaries before consulting the {@link CachingRangeReader} cache. Disabled by
+     * default; enable explicitly for storage backends that benefit from block-sized reads. Only meaningful when
+     * {@link #MEMORY_CACHE_ENABLED} is true.
      */
     public static final StorageParameter<Boolean> MEMORY_CACHE_BLOCK_ALIGNED =
             CachingProviderHelper.MEMORY_CACHE_BLOCK_ALIGNED;

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/CachingProviderHelper.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/spi/CachingProviderHelper.java
@@ -62,6 +62,10 @@ public final class CachingProviderHelper {
     /**
      * A {@link StorageParameter} to control whether cached byte ranges should be block-aligned. Block alignment can
      * improve performance for certain storage types by optimizing read patterns.
+     *
+     * <p>Disabled by default: the formats this library targets (PMTiles, GeoParquet, COPC, GeoZarr) issue precise range
+     * reads, and block alignment would inflate them. Enable it explicitly through this parameter, or by calling
+     * {@code CachingRangeReader.Builder#withBlockAlignment()} directly.
      */
     public static final StorageParameter<Boolean> MEMORY_CACHE_BLOCK_ALIGNED = StorageParameter.builder()
             .key("storage.caching.blockaligned")
@@ -76,11 +80,14 @@ public final class CachingProviderHelper {
 
                     It also helps in reducing the number of small, fragmented reads.
 
+                    Disabled by default; formats designed for ranged reads request exactly \
+                    the bytes they need.
+
                     This setting is only effective when caching is enabled.
                     """)
             .type(Boolean.class)
             .group(GROUP_CACHING)
-            .defaultValue(true)
+            .defaultValue(false)
             .build();
 
     /**
@@ -160,7 +167,7 @@ public final class CachingProviderHelper {
             return Optional.empty();
         }
         final boolean blockAligned =
-                opts.getParameter(MEMORY_CACHE_BLOCK_ALIGNED).orElse(true);
+                opts.getParameter(MEMORY_CACHE_BLOCK_ALIGNED).orElse(false);
         final Optional<Integer> blockSize = opts.getParameter(MEMORY_CACHE_BLOCK_SIZE);
         return Optional.of(reader -> {
             Builder builder = CachingRangeReader.builder(reader);

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/cache/CachingProviderHelperTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/cache/CachingProviderHelperTest.java
@@ -61,7 +61,7 @@ class CachingProviderHelperTest {
     }
 
     @Test
-    void blockalignedDefaultStillAligns() throws IOException {
+    void blockalignedAbsentDoesNotAlign() throws IOException {
         Path testFile = writeRandomFile();
 
         StorageConfig opts =
@@ -75,7 +75,57 @@ class CachingProviderHelperTest {
             ByteBuffer out = ByteBuffer.allocate(16);
             reader.readRange(2000, 1, out);
 
+            assertThat(reader.getEstimatedCacheSizeBytes()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void blockalignedTrueAligns() throws IOException {
+        Path testFile = writeRandomFile();
+
+        StorageConfig opts = new StorageConfig(testFile.toUri())
+                .setParameter(CachingProviderHelper.MEMORY_CACHE_ENABLED, true)
+                .setParameter(CachingProviderHelper.MEMORY_CACHE_BLOCK_ALIGNED, true);
+
+        try (RangeReader base = RangeReaderTestSupport.fileReader(testFile);
+                CachingRangeReader reader = (CachingRangeReader) CachingProviderHelper.cachingDecoratorFor(opts)
+                        .orElseThrow()
+                        .apply(base)) {
+
+            ByteBuffer out = ByteBuffer.allocate(16);
+            reader.readRange(2000, 1, out);
+
             assertThat(reader.getEstimatedCacheSizeBytes()).isEqualTo(64L * 1024);
+        }
+    }
+
+    @Test
+    void blockalignedDeclaredDefaultIsFalse() {
+        assertThat(CachingProviderHelper.MEMORY_CACHE_BLOCK_ALIGNED.defaultValue())
+                .contains(false);
+    }
+
+    /**
+     * {@code StorageProvider.createConfig()} pre-populates configs with the declared parameter defaults; the resulting
+     * config must not enable block alignment either.
+     */
+    @Test
+    void configWithDeclaredDefaultsDoesNotAlign() throws IOException {
+        Path testFile = writeRandomFile();
+
+        StorageConfig opts = StorageConfig.withDefaults(CachingProviderHelper.configParameters())
+                .baseUri(testFile.toUri())
+                .setParameter(CachingProviderHelper.MEMORY_CACHE_ENABLED, true);
+
+        try (RangeReader base = RangeReaderTestSupport.fileReader(testFile);
+                CachingRangeReader reader = (CachingRangeReader) CachingProviderHelper.cachingDecoratorFor(opts)
+                        .orElseThrow()
+                        .apply(base)) {
+
+            ByteBuffer out = ByteBuffer.allocate(16);
+            reader.readRange(2000, 1, out);
+
+            assertThat(reader.getEstimatedCacheSizeBytes()).isEqualTo(1L);
         }
     }
 


### PR DESCRIPTION
`MEMORY_CACHE_BLOCK_ALIGNED` defaulted to `true`, both in the parameter declaration and in the cachingDecoratorFor fallback. The formats this library targets (PMTiles, GeoParquet, COPC, GeoZarr) issue precise range reads; block alignment inflates them and must be requested explicitly through the parameter or the `CachingRangeReader` builder.

Default both places to `false`,  also matching the builder's default, which never aligned unless `withBlockAlignment()` or `blockSize()` was called.
