### PR TITLE
feat(storage): lazy range reader metadata

### DIFF
--- a/docs/src/storage/explanation/internals.md
+++ b/docs/src/storage/explanation/internals.md
@@ -14,7 +14,7 @@ public interface RangeReader extends Closeable {
     int readRange(long offset, int length, ByteBuffer target) throws IOException;
     
     // Metadata
-    long size() throws IOException;
+    OptionalLong size();
     String getSourceIdentifier();
 }
 ```

--- a/docs/src/storage/how-to/troubleshoot.md
+++ b/docs/src/storage/how-to/troubleshoot.md
@@ -419,7 +419,7 @@ public void monitorCache(RangeReader reader) {
 public void testConnectivity(URI uri) {
     try {
         var reader = createReader(uri);
-        long size = reader.size();
+        long size = reader.size().orElseThrow();
         System.out.println("Successfully connected to " + uri + ", size: " + size);
         reader.close();
     } catch (Exception e) {

--- a/docs/src/storage/index.md
+++ b/docs/src/storage/index.md
@@ -9,7 +9,7 @@ The `Storage` API is the recommended entrypoint when you need anything beyond by
 | URI scheme | Backend | Notes |
 | :--- | :--- | :--- |
 | `file:` | Local filesystem | Real directories, atomic rename |
-| `http:`, `https:` | HTTP / HTTPS | Read-only; HEAD + range GET |
+| `http:`, `https:` | HTTP / HTTPS | Read-only; range GET |
 | `s3:`, `s3a:` | AWS S3 | General-purpose buckets and S3 Express One Zone (Directory Buckets) |
 | `https://*.blob.core.windows.net`, `az:` | Azure Blob Storage | Flat keyspace + virtual directories. `az://<account>/<container>/<path>` is a short-form alias for the canonical `https://` URL (DuckDB / fsspec convention). |
 | `abfs:`, `abfss:`, `https://*.dfs.core.windows.net` | Azure Data Lake Storage Gen2 | Real directories + atomic rename when HNS is enabled |

--- a/docs/src/storage/reference/rangereader-recipes.md
+++ b/docs/src/storage/reference/rangereader-recipes.md
@@ -62,7 +62,7 @@ The Tileverse Range Reader provides a unified interface for reading byte ranges 
 public interface RangeReader extends Closeable {
     ByteBuffer readRange(long offset, int length) throws IOException;
     int readRange(long offset, int length, ByteBuffer target) throws IOException;
-    long size() throws IOException;
+    OptionalLong size();
     String getSourceIdentifier();
 }
 ```
@@ -104,7 +104,7 @@ tileData.flip();
 Process large files in chunks:
 
 ```java
-long fileSize = reader.size();
+long fileSize = reader.size().orElseThrow();
 int chunkSize = 1024 * 1024; // 1MB chunks
 
 for (long offset = 0; offset < fileSize; offset += chunkSize) {

--- a/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobRangeReader.java
+++ b/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobRangeReader.java
@@ -17,6 +17,7 @@ package io.tileverse.storage.azure;
 
 import static java.util.Objects.requireNonNull;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.rest.Response;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobRange;
@@ -24,13 +25,14 @@ import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.DownloadRetryOptions;
 import io.tileverse.storage.AbstractRangeReader;
-import io.tileverse.storage.NotFoundException;
+import io.tileverse.storage.ContentRange;
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.StorageException;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -42,32 +44,18 @@ import lombok.extern.slf4j.Slf4j;
 class AzureBlobRangeReader extends AbstractRangeReader implements RangeReader {
 
     private final BlobClient blobClient;
-    private long contentLength = -1;
+    private final AtomicReference<OptionalLong> contentLength = new AtomicReference<>();
 
     /**
      * Creates a new AzureBlobRangeReader for the specified blob.
      *
+     * <p>Construction performs no I/O. A missing blob is reported by the first {@link #readRange(long, int)} or
+     * {@link #size()} call instead of at construction time.
+     *
      * @param blobClient The Azure Blob client to read from
-     * @throws StorageException If a storage error occurs
      */
     AzureBlobRangeReader(BlobClient blobClient) {
         this.blobClient = requireNonNull(blobClient, "BlobClient cannot be null");
-
-        // Check if the blob exists and get its content length
-        try {
-            if (!blobClient.exists().booleanValue()) {
-                throw new NotFoundException("Blob does not exist: " + blobClient.getBlobUrl());
-            }
-
-            this.contentLength = blobClient.getProperties().getBlobSize();
-        } catch (BlobStorageException e) {
-            throw AzureExceptionMapper.map(e, blobClient.getBlobUrl());
-        } catch (StorageException e) {
-            throw e;
-        } catch (RuntimeException e) {
-            throw new StorageException(
-                    "failure to access %s: %s".formatted(blobClient.getBlobUrl(), e.getMessage()), e);
-        }
     }
 
     @Override
@@ -101,6 +89,12 @@ class AzureBlobRangeReader extends AbstractRangeReader implements RangeReader {
                 throw new StorageException("Failed to download blob range, status code: " + response.getStatusCode());
             }
 
+            if (contentLength.get() == null) {
+                String contentRange = response.getHeaders().getValue(HttpHeaderName.CONTENT_RANGE);
+                ContentRange.totalOf(contentRange)
+                        .ifPresent(total -> contentLength.compareAndSet(null, OptionalLong.of(total)));
+            }
+
             // Copy the bytes directly into the target buffer
             byte[] data = outputStream.toByteArray();
             target.put(data);
@@ -117,16 +111,21 @@ class AzureBlobRangeReader extends AbstractRangeReader implements RangeReader {
 
     @Override
     public OptionalLong size() {
-        if (contentLength < 0) {
-            try {
-                contentLength = blobClient.getProperties().getBlobSize();
-            } catch (BlobStorageException e) {
-                throw AzureExceptionMapper.map(e, blobClient.getBlobUrl());
-            } catch (Exception e) {
-                throw new StorageException("Failed to get blob size: " + e.getMessage(), e);
-            }
+        OptionalLong known = contentLength.get();
+        if (known == null) {
+            known = contentLength.updateAndGet(current -> current != null ? current : fetchSize());
         }
-        return OptionalLong.of(contentLength);
+        return known;
+    }
+
+    private OptionalLong fetchSize() {
+        try {
+            return OptionalLong.of(blobClient.getProperties().getBlobSize());
+        } catch (BlobStorageException e) {
+            throw AzureExceptionMapper.map(e, blobClient.getBlobUrl());
+        } catch (RuntimeException e) {
+            throw new StorageException("Failed to get blob size: " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobStorage.java
+++ b/tileverse-storage/azure/src/main/java/io/tileverse/storage/azure/AzureBlobStorage.java
@@ -44,7 +44,6 @@ import com.azure.storage.blob.specialized.BlobInputStream;
 import io.tileverse.storage.CopyOptions;
 import io.tileverse.storage.DeleteResult;
 import io.tileverse.storage.ListOptions;
-import io.tileverse.storage.NotFoundException;
 import io.tileverse.storage.PreconditionFailedException;
 import io.tileverse.storage.PresignWriteOptions;
 import io.tileverse.storage.RangeReader;
@@ -273,9 +272,6 @@ final class AzureBlobStorage implements Storage {
     @Override
     public RangeReader openRangeReader(String key) {
         requireOpen();
-        if (stat(key).isEmpty()) {
-            throw new NotFoundException("Blob not found: " + location.resolve(key));
-        }
         return new AzureBlobRangeReader(blobClient(key));
     }
 

--- a/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobOvertureMapsLiveIT.java
+++ b/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobOvertureMapsLiveIT.java
@@ -177,10 +177,10 @@ class AzureBlobOvertureMapsLiveIT {
     }
 
     @Test
-    void openRangeReaderThrowsNotFoundForMissingKey() throws IOException {
-        try (Storage storage = StorageFactory.open(baseUri, anonymousProps())) {
-            assertThatThrownBy(() -> storage.openRangeReader("does/not/exist.parquet"))
-                    .isInstanceOf(NotFoundException.class);
+    void openRangeReaderThrowsNotFoundOnFirstReadForMissingKey() throws IOException {
+        try (Storage storage = StorageFactory.open(baseUri, anonymousProps());
+                RangeReader reader = storage.openRangeReader("does/not/exist.parquet")) {
+            assertThatThrownBy(() -> reader.readRange(0, 4)).isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobRangeReaderTest.java
+++ b/tileverse-storage/azure/src/test/java/io/tileverse/storage/azure/AzureBlobRangeReaderTest.java
@@ -15,19 +15,30 @@
  */
 package io.tileverse.storage.azure;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpResponse;
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobDownloadResponse;
 import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobStorageException;
+import io.tileverse.storage.NotFoundException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.OptionalLong;
@@ -69,9 +80,6 @@ class AzureBlobRangeReaderTest {
 
         // Setup mock behavior - use lenient() to avoid unnecessary stubbing errors
         lenient().when(blobClient.getBlobUrl()).thenReturn(BLOB_URL);
-        lenient().when(blobClient.exists()).thenReturn(true);
-        lenient().when(blobClient.getProperties()).thenReturn(blobProperties);
-        lenient().when(blobProperties.getBlobSize()).thenReturn((long) CONTENT_LENGTH);
 
         // The key insight here is to mock AzureBlobRangeReader methods directly instead
         // of trying to mock complex Azure SDK classes that are final and difficult to mock
@@ -113,11 +121,20 @@ class AzureBlobRangeReaderTest {
         });
     }
 
+    /** Stubs the properties response consumed by the real (non-overridden) {@code size()} path. */
+    private void stubProperties() {
+        when(blobClient.getProperties()).thenReturn(blobProperties);
+        when(blobProperties.getBlobSize()).thenReturn((long) CONTENT_LENGTH);
+    }
+
+    @Test
+    void testConstructorMakesNoRequests() {
+        new AzureBlobRangeReader(blobClient);
+        verifyNoInteractions(blobClient);
+    }
+
     @Test
     void testGetSize() {
-        // Reset the invocation count for getProperties after setup
-        clearInvocations(blobClient);
-
         // Since we're using a spied instance with overridden methods,
         // we just verify the size is as expected
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
@@ -127,9 +144,59 @@ class AzureBlobRangeReaderTest {
     }
 
     @Test
-    void testConstructorVerifiesExists() {
-        // Verify the constructor checks if blob exists
-        verify(blobClient).exists();
+    void testSizeIsLazyAndMemoized() {
+        stubProperties();
+        AzureBlobRangeReader lazy = new AzureBlobRangeReader(blobClient);
+        verify(blobClient, never()).getProperties();
+
+        assertThat(lazy.size()).hasValue(CONTENT_LENGTH);
+        assertThat(lazy.size()).hasValue(CONTENT_LENGTH);
+        verify(blobClient, times(1)).getProperties();
+    }
+
+    @Test
+    void testSizeCapturedFromRangeResponseWithoutProperties() {
+        int length = 10;
+        byte[] slice = Arrays.copyOfRange(TEST_DATA, 0, length);
+
+        BlobDownloadResponse response = mock(BlobDownloadResponse.class);
+        when(response.getStatusCode()).thenReturn(206);
+        HttpHeaders headers =
+                new HttpHeaders().set(HttpHeaderName.CONTENT_RANGE, "bytes 0-" + (length - 1) + "/" + CONTENT_LENGTH);
+        when(response.getHeaders()).thenReturn(headers);
+        when(blobClient.downloadStreamWithResponse(any(), any(), any(), any(), anyBoolean(), any(), any()))
+                .thenAnswer(invocation -> {
+                    OutputStream out = invocation.getArgument(0);
+                    out.write(slice);
+                    return response;
+                });
+
+        AzureBlobRangeReader lazy = new AzureBlobRangeReader(blobClient);
+        lazy.readRange(0, length);
+
+        assertThat(lazy.size()).hasValue(CONTENT_LENGTH);
+        verify(blobClient, never()).getProperties();
+    }
+
+    @Test
+    void testNotFoundThrownOnFirstReadNotAtConstruction() {
+        AzureBlobRangeReader missing = new AzureBlobRangeReader(blobClient);
+        BlobStorageException notFound = notFoundException();
+        when(blobClient.downloadStreamWithResponse(any(), any(), any(), any(), anyBoolean(), any(), any()))
+                .thenThrow(notFound);
+
+        assertThatThrownBy(() -> missing.readRange(0, 10)).isInstanceOf(NotFoundException.class);
+    }
+
+    /**
+     * Builds a real {@link BlobStorageException} wired to a 404 response. This flows through
+     * {@link AzureExceptionMapper#map} the same way a live Azure 404 would: the mapper reads the status from
+     * {@code getResponse().getStatusCode()}, which a bare mock of {@code BlobStorageException} itself would leave null.
+     */
+    private static BlobStorageException notFoundException() {
+        HttpResponse response = mock(HttpResponse.class);
+        when(response.getStatusCode()).thenReturn(404);
+        return new BlobStorageException("BlobNotFound", response, null);
     }
 
     @Test
@@ -200,25 +267,5 @@ class AzureBlobRangeReaderTest {
 
         // Should return empty buffer
         assertEquals(0, buffer.remaining());
-    }
-
-    @Test
-    void testBlobDoesNotExist() {
-        // Reset the mock to change behavior
-        reset(blobClient);
-        when(blobClient.exists()).thenReturn(false);
-
-        assertThatThrownBy(() -> new AzureBlobRangeReader(blobClient))
-                .isInstanceOf(io.tileverse.storage.NotFoundException.class);
-    }
-
-    @Test
-    void testBlobExceptionDuringConstruction() {
-        // Reset the mock to change behavior
-        reset(blobClient);
-        when(blobClient.exists()).thenThrow(new RuntimeException("Failed to check blob existence"));
-
-        assertThatThrownBy(() -> new AzureBlobRangeReader(blobClient))
-                .isInstanceOf(io.tileverse.storage.StorageException.class);
     }
 }

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/AbstractRangeReader.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/AbstractRangeReader.java
@@ -17,7 +17,6 @@ package io.tileverse.storage;
 
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
-import java.util.OptionalLong;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -63,8 +62,9 @@ public abstract class AbstractRangeReader implements RangeReader {
      *
      * <ul>
      *   <li>For zero-length reads, returns immediately with 0 bytes read
-     *   <li>For reads starting beyond EOF, returns 0 bytes read
-     *   <li>For reads extending beyond EOF, truncates to available data
+     *   <li>For reads starting at or beyond EOF, returns 0 bytes read (backends signal this case with
+     *       {@link RangeNotSatisfiableException}, translated here)
+     *   <li>For reads extending beyond EOF, the backend returns only the available bytes
      * </ul>
      *
      * <p><strong>Buffer Management (NIO Conventions):</strong> Following standard Java NIO conventions, this method
@@ -118,22 +118,13 @@ public abstract class AbstractRangeReader implements RangeReader {
                     "Target buffer has insufficient remaining capacity: " + remainingBefore + " < " + length);
         }
 
-        int actualLength = length;
-
-        final OptionalLong fileSize = size();
-        if (fileSize.isPresent()) {
-            long size = fileSize.getAsLong();
-            if (offset >= size) {
-                // Offset is beyond EOF, return 0 bytes read (position unchanged)
-                return 0;
-            }
-            if (offset + length > size) {
-                // Read extends beyond EOF, truncate it
-                actualLength = (int) (size - offset);
-            }
+        try {
+            return readRangeNoFlip(offset, length, target);
+        } catch (RangeNotSatisfiableException pastEof) {
+            // The backend answered 416: the offset is at or past EOF. Preserve the documented
+            // contract of returning 0 bytes read with the buffer position unchanged.
+            return 0;
         }
-
-        return readRangeNoFlip(offset, actualLength, target);
     }
 
     /**
@@ -152,6 +143,9 @@ public abstract class AbstractRangeReader implements RangeReader {
      *   <li>Do NOT modify the target buffer's limit
      *   <li>Return the actual number of bytes read (may be less than requested if EOF reached)
      *   <li>Must be thread-safe for concurrent access
+     *   <li>The requested range may start at or past EOF, or extend beyond it. Return 0 or a short count in that case,
+     *       or throw {@link RangeNotSatisfiableException} for a past-EOF offset; the calling {@code readRange}
+     *       translates it to 0 bytes read.
      * </ul>
      *
      * <p><strong>Parameter Guarantees:</strong> When this method is called by {@link #readRange(long, int,
@@ -162,8 +156,6 @@ public abstract class AbstractRangeReader implements RangeReader {
      *   <li>{@literal actualLength > 0} (zero-length reads are handled by the caller)
      *   <li>{@code target} is not null and not read-only
      *   <li>{@literal target.remaining() >= actualLength}
-     *   <li>{@literal offset < source.size()} (reads starting beyond EOF are handled by caller)
-     *   <li>{@code actualLength} may be less than originally requested if the read would extend beyond EOF
      * </ul>
      *
      * <p><strong>Buffer State Contract:</strong>
@@ -182,7 +174,7 @@ public abstract class AbstractRangeReader implements RangeReader {
      * <p>The calling {@code readRange} method will then reset the position and adjust the limit to prepare the buffer
      * for immediate consumption by the caller.
      *
-     * @param offset The byte offset to read from (guaranteed to be {@literal >= 0 and < source size})
+     * @param offset The byte offset to read from (guaranteed to be {@literal >= 0}; may be at or past EOF)
      * @param actualLength The number of bytes to read (guaranteed to be {@literal > 0} and within buffer capacity)
      * @param target The ByteBuffer to write into (guaranteed to be non-null, writable, and have sufficient capacity)
      * @return The number of bytes actually read and written to the target buffer

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/ContentRange.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/ContentRange.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage;
+
+import java.util.OptionalLong;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Parsing helper for the HTTP {@code Content-Range} response header, whose complete-length field tells the total object
+ * size ("bytes 0-9/1234" or, on a 416, "bytes &#42;/1234").
+ */
+public final class ContentRange {
+
+    private ContentRange() {}
+
+    /**
+     * Extracts the complete-length from a {@code Content-Range} header value.
+     *
+     * @param contentRangeHeader the raw header value, may be null
+     * @return the total size after the slash, or empty when absent, unknown ("*"), or unparseable
+     */
+    public static OptionalLong totalOf(@Nullable String contentRangeHeader) {
+        if (contentRangeHeader == null) {
+            return OptionalLong.empty();
+        }
+        int slash = contentRangeHeader.lastIndexOf('/');
+        if (slash < 0 || slash == contentRangeHeader.length() - 1) {
+            return OptionalLong.empty();
+        }
+        String total = contentRangeHeader.substring(slash + 1).trim();
+        if ("*".equals(total)) {
+            return OptionalLong.empty();
+        }
+        try {
+            return OptionalLong.of(Long.parseLong(total));
+        } catch (NumberFormatException notANumber) {
+            return OptionalLong.empty();
+        }
+    }
+}

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/KnownSizeRangeReader.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/KnownSizeRangeReader.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.OptionalLong;
+
+/**
+ * Forwarding {@link RangeReader} that answers {@link #size()} from a value the caller already knows, typically from a
+ * storage listing, saving the delegate's lazy metadata request. Everything else, the source identity included, forwards
+ * to the delegate unchanged.
+ *
+ * <p>The seeded size reflects the listing observation; if the object is replaced afterwards, reads return whatever the
+ * backend serves for the requested offsets.
+ */
+final class KnownSizeRangeReader implements RangeReader {
+
+    private final RangeReader delegate;
+    private final long size;
+
+    private KnownSizeRangeReader(RangeReader delegate, long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("size cannot be negative: " + size);
+        }
+        this.delegate = delegate;
+        this.size = size;
+    }
+
+    static RangeReader of(RangeReader delegate, long size) {
+        return new KnownSizeRangeReader(delegate, size);
+    }
+
+    @Override
+    public int readRange(long offset, int length, ByteBuffer target) {
+        return delegate.readRange(offset, length, target);
+    }
+
+    @Override
+    public OptionalLong size() {
+        return OptionalLong.of(size);
+    }
+
+    @Override
+    public String getSourceIdentifier() {
+        return delegate.getSourceIdentifier();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/RangeReader.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/RangeReader.java
@@ -95,6 +95,9 @@ public interface RangeReader extends Closeable, Supplier<SeekableByteChannel> {
      * read, and the caller must call {@code flip()} on the buffer to prepare it for reading. The caller is responsible
      * for ensuring that the target buffer has sufficient remaining capacity for the requested length.
      *
+     * <p>Implementations bound to a remote object defer existence checks: a missing object is reported as a
+     * {@link NotFoundException} from the first read or {@link #size()} call rather than at construction time.
+     *
      * @param offset The offset to read from
      * @param length The number of bytes to read
      * @param target The ByteBuffer to read into, starting at its current position

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/Storage.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/Storage.java
@@ -132,15 +132,36 @@ public interface Storage extends Closeable {
      * and must be closed; closing the reader releases per-blob state but leaves this Storage open. Closing the Storage
      * closes the underlying SDK client and invalidates any open readers obtained from it.
      *
+     * <p>For remote backends (S3, Azure, GCS, HTTP), opening performs no I/O: the key is not checked until the first
+     * read or {@link RangeReader#size() size} call on the returned reader, which throws {@link NotFoundException} if no
+     * object exists at the key. The local file backend throws it directly from this method instead, since a filesystem
+     * stat is effectively free. Callers that need fail-fast validation should call {@link #stat(String)} first.
+     *
      * <p>The returned reader can be wrapped with the standard decorators ({@code CachingRangeReader},
      * {@code BlockAlignedRangeReader}) just like a directly-constructed reader.
      *
      * @param key key relative to {@link #baseUri()}
      * @return a thread-safe RangeReader bound to the blob
-     * @throws NotFoundException if no object exists at the key
      * @throws StorageException on transport or authorization failures
      */
     RangeReader openRangeReader(String key);
+
+    /**
+     * Open a {@link RangeReader} for a listed blob, seeding the object size from the listing entry such that
+     * {@link RangeReader#size()} answers without any metadata request. Equivalent to {@link #openRangeReader(String)}
+     * for {@code entry.key()} otherwise; the reader's {@link RangeReader#getSourceIdentifier() source identifier} is
+     * identical.
+     *
+     * <p>The seeded size reflects the listing observation; if the object is replaced between listing and reading, reads
+     * return whatever the backend serves for the requested offsets.
+     *
+     * @param entry a file entry obtained from this storage's listing or stat operations
+     * @return a thread-safe RangeReader bound to the blob, answering size() from the entry
+     */
+    default RangeReader openRangeReader(StorageEntry.File entry) {
+        Objects.requireNonNull(entry, "entry");
+        return KnownSizeRangeReader.of(openRangeReader(entry.key()), entry.size());
+    }
 
     /**
      * Open a {@link RangeReader} from an absolute URI within this Storage's namespace. Equivalent to
@@ -154,8 +175,9 @@ public interface Storage extends Closeable {
      * <p>A query string on {@code uri} is preserved into the derived key (load-bearing for HTTP-backed Storages whose
      * URLs carry signatures, SAS tokens, or routing parameters). A fragment is dropped silently because RFC 3986
      * fragments are client-only and never reach the server. Backends whose key grammar cannot represent a query string
-     * (File, S3, Azure, GCS path-style) will throw a {@link NotFoundException} from {@link #openRangeReader(String)}
-     * when the resulting key has no matching object.
+     * (S3, Azure, GCS path-style) report a missing derived key as {@link NotFoundException} from the first read or
+     * {@link RangeReader#size() size} call on the returned reader, not from this method. The local file backend has the
+     * same key-grammar limitation but reports a missing derived key at open, directly from this method.
      *
      * <p><b>Path traversal:</b> {@code ..} and {@code .} segments are normalized before the namespace check; URIs whose
      * normalized path falls outside {@code baseUri()} are rejected. Percent-encoded traversal segments ({@code %2E%2E}
@@ -165,7 +187,6 @@ public interface Storage extends Closeable {
      * @return a thread-safe RangeReader bound to the blob
      * @throws IllegalArgumentException if {@code uri} is not within {@link #baseUri()}, equals {@code baseUri()}, or
      *     contains a percent-encoded path-traversal segment
-     * @throws NotFoundException if no object exists at the derived key
      * @throws StorageException on transport or authorization failures
      */
     default RangeReader openRangeReader(URI uri) {

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/RangeReaderReadableByteChannel.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/RangeReaderReadableByteChannel.java
@@ -110,28 +110,12 @@ public class RangeReaderReadableByteChannel implements ReadableByteChannel {
         }
 
         final long currentPosition = position.get();
-        final OptionalLong sourceSize = rangeReader.size();
-
-        // Check if we're at or beyond the end of the source
-        if (sourceSize.isPresent() && currentPosition >= sourceSize.getAsLong()) {
+        final int bytesRead = rangeReader.readRange(currentPosition, dst.remaining(), dst);
+        if (bytesRead == 0) {
+            // A zero-byte result for a nonzero request means the position is at or past EOF.
             return -1;
         }
-
-        // Calculate how many bytes we can actually read
-        final int requestedBytes = dst.remaining();
-        final long availableBytes = sourceSize.isEmpty() ? requestedBytes : (sourceSize.getAsLong() - currentPosition);
-        final int bytesToRead = (int) Math.min(requestedBytes, availableBytes);
-
-        if (bytesToRead <= 0) {
-            return -1;
-        }
-
-        // Read from the RangeReader
-        final int bytesRead = rangeReader.readRange(currentPosition, bytesToRead, dst);
-
-        // Advance the position
         position.addAndGet(bytesRead);
-
         return bytesRead;
     }
 
@@ -233,16 +217,7 @@ public class RangeReaderReadableByteChannel implements ReadableByteChannel {
         if (!open.get()) {
             return "RangeReaderReadableByteChannel[closed]";
         }
-
-        try {
-            return "RangeReaderReadableByteChannel[source=%s, position=%d, size=%d]"
-                    .formatted(
-                            rangeReader.getSourceIdentifier(),
-                            position.get(),
-                            rangeReader.size().orElse(-1));
-        } catch (RuntimeException e) {
-            return "RangeReaderReadableByteChannel[source=%s, position=%d, size=unknown]"
-                    .formatted(rangeReader.getSourceIdentifier(), position.get());
-        }
+        return "RangeReaderReadableByteChannel[source=%s, position=%d]"
+                .formatted(rangeReader.getSourceIdentifier(), position.get());
     }
 }

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannel.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannel.java
@@ -131,16 +131,7 @@ public final class RangeReaderSeekableByteChannel extends RangeReaderReadableByt
         if (!open.get()) {
             return "RangeReaderSeekableByteChannel[closed]";
         }
-
-        try {
-            return "RangeReaderSeekableByteChannel[source=%s, position=%d, size=%d]"
-                    .formatted(
-                            rangeReader.getSourceIdentifier(),
-                            position.get(),
-                            rangeReader.size().orElse(-1));
-        } catch (RuntimeException e) {
-            return "RangeReaderSeekableByteChannel[source=%s, position=%d, size=unknown]"
-                    .formatted(rangeReader.getSourceIdentifier(), position.get());
-        }
+        return "RangeReaderSeekableByteChannel[source=%s, position=%d]"
+                .formatted(rangeReader.getSourceIdentifier(), position.get());
     }
 }

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/file/FileRangeReader.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/file/FileRangeReader.java
@@ -152,10 +152,14 @@ class FileRangeReader extends AbstractRangeReader implements RangeReader {
      */
     @Override
     public OptionalLong size() {
+        checkNotClosed();
+        return OptionalLong.of(this.size);
+    }
+
+    private void checkNotClosed() {
         if (permanentlyClosed.get()) {
             throw new IllegalStateException("FileRangeReader is closed");
         }
-        return OptionalLong.of(this.size);
     }
 
     /**
@@ -218,9 +222,11 @@ class FileRangeReader extends AbstractRangeReader implements RangeReader {
      * @param target the ByteBuffer to read data into (limit will be adjusted)
      * @return the actual number of bytes read, which may be less than actualLength if EOF is reached
      * @throws StorageException if an I/O error occurs during reading
+     * @throws IllegalStateException if this reader has been permanently closed via {@link #close()}
      */
     @Override
     protected int readRangeNoFlip(long offset, int actualLength, ByteBuffer target) {
+        checkNotClosed();
         final int initialPosition = target.position();
         final int initialLimit = target.limit();
         target.limit(initialPosition + actualLength);

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/http/HttpRangeReader.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/http/HttpRangeReader.java
@@ -19,6 +19,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.tileverse.storage.AbstractRangeReader;
 import io.tileverse.storage.AccessDeniedException;
+import io.tileverse.storage.ContentRange;
+import io.tileverse.storage.NotFoundException;
+import io.tileverse.storage.RangeNotSatisfiableException;
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.StorageException;
 import io.tileverse.storage.TransientStorageException;
@@ -36,7 +39,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -63,14 +65,10 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
     private final HttpClient httpClient;
     private final HttpAuthentication authentication;
 
-    /** @see #getHeadResponse() */
-    private final AtomicReference<HeadResponse> headResponse = new AtomicReference<>(null);
+    private record Metadata(OptionalLong contentLength, Optional<String> etag, Optional<String> lastModified) {}
 
-    private record HeadResponse(
-            boolean supportsByteRange,
-            OptionalLong contentLength,
-            Optional<String> etag,
-            Optional<String> lastModified) {}
+    /** Populated by the first HEAD (size() before any read) or the first range response. */
+    private final AtomicReference<Metadata> metadata = new AtomicReference<>(null);
 
     /**
      * Creates a new HttpRangeReader with a custom HTTP client and authentication.
@@ -83,12 +81,16 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
         this.uri = requireNonNull(uri);
         this.httpClient = requireNonNull(httpClient);
         this.authentication = requireNonNull(authentication);
-        // Content length and range support will be checked when size() is first called
+        // Content length will be checked when size() is first called
     }
 
     @Override
     public OptionalLong size() {
-        return getHeadResponse().contentLength();
+        Metadata known = metadata.get();
+        if (known == null) {
+            known = metadata.updateAndGet(this::fetchMetadata);
+        }
+        return known.contentLength();
     }
 
     @Override
@@ -105,8 +107,6 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
 
     @Override
     protected int readRangeNoFlip(final long offset, final int actualLength, ByteBuffer target) {
-        checkServerSupportsByteRanges();
-
         try {
             return getRange(offset, actualLength, target);
         } catch (IOException e) {
@@ -185,6 +185,7 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
             throw rethrow(timeout);
         }
         checkStatusCode(response);
+        captureMetadataFrom(response);
         checkContentLength(length, response);
         return response;
     }
@@ -200,18 +201,51 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
         });
     }
 
-    private void checkStatusCode(HttpResponse<?> response) {
+    private void checkStatusCode(HttpResponse<InputStream> response) {
         int statusCode = response.statusCode();
+        if (statusCode == 206) {
+            return;
+        }
+        closeBodyQuietly(response);
         switch (statusCode) {
-            case 206:
-                // all good
-                break;
+            case 200:
+                throw new StorageException("Server ignored the Range header (HTTP 200) for URI: " + uri
+                        + "; range requests are not supported by this server");
             case 401, 403:
                 throw new AccessDeniedException(
                         "Authentication failed for URI: " + uri + ", status code: " + statusCode);
+            case 404:
+                throw new NotFoundException("Resource not found: " + uri);
+            case 416:
+                throw new RangeNotSatisfiableException("Requested range not satisfiable for URI: " + uri);
             default:
                 throw new StorageException("Failed to get range from URI: " + uri + ", status code: " + statusCode);
         }
+    }
+
+    private static void closeBodyQuietly(HttpResponse<InputStream> response) {
+        try (InputStream body = response.body()) {
+            // drain nothing; closing releases the connection
+        } catch (IOException ignored) {
+            // the connection is being abandoned anyway
+        }
+    }
+
+    /**
+     * Captures size, ETag, and Last-Modified from the first range response, when not already known, sparing
+     * {@link #size()} a HEAD request. Only commits when the {@code Content-Range} total parses: a server that omits or
+     * malforms it on a 206 leaves the metadata unset, and a later {@link #size()} call then falls back to a HEAD
+     * instead of memoizing an unresolved size forever.
+     */
+    private void captureMetadataFrom(HttpResponse<InputStream> response) {
+        if (metadata.get() != null) {
+            return;
+        }
+        OptionalLong total = ContentRange.totalOf(
+                response.headers().firstValue("Content-Range").orElse(null));
+        Optional<String> etag = response.headers().firstValue("ETag");
+        Optional<String> lastModified = response.headers().firstValue("Last-Modified");
+        total.ifPresent(size -> metadata.compareAndSet(null, new Metadata(OptionalLong.of(size), etag, lastModified)));
     }
 
     private HttpRequest buildRangeRequest(final long offset, final int length) {
@@ -225,30 +259,7 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
         return requestBuilder.build();
     }
 
-    private void checkServerSupportsByteRanges() {
-        HeadResponse head = getHeadResponse();
-        if (!head.supportsByteRange()) {
-            throw new StorageException("Server explicitly does not support range requests (Accept-Ranges: none)");
-        }
-    }
-
-    /**
-     * Makes a HEAD request to the server and caches the response for reuse. This method is thread-safe and ensures the
-     * HEAD request is made only once.
-     *
-     * @return the cached HEAD response
-     * @throws StorageException If a storage error occurs during the HEAD request
-     */
-    private HeadResponse getHeadResponse() {
-
-        HeadResponse response = headResponse.get();
-        if (response == null) {
-            response = headResponse.updateAndGet(this::fetchHeadResponse);
-        }
-        return response;
-    }
-
-    private HeadResponse fetchHeadResponse(HeadResponse currValue) {
+    private Metadata fetchMetadata(Metadata currValue) {
         if (currValue != null) {
             // another thread already populated the cache while we were racing into updateAndGet, skip the redundant
             // HEAD and adopt their result.
@@ -265,10 +276,6 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
 
             check200StatusCode(response);
 
-            final boolean supportsByteRanges = supportsByteRanges(response);
-            if (!supportsByteRanges) {
-                log.warn("{} does not support byte ranges", uri);
-            }
             OptionalLong contentLength = contentLength(response);
             if (contentLength.isEmpty()) {
                 log.warn("Content-Length unknown for {}", uri);
@@ -277,7 +284,7 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
             }
             Optional<String> etag = etag(response);
             Optional<String> lastModified = lastModified(response);
-            return new HeadResponse(supportsByteRanges, contentLength, etag, lastModified);
+            return new Metadata(contentLength, etag, lastModified);
         } catch (HttpConnectTimeoutException timeout) {
             throw rethrow(timeout);
         } catch (IOException e) {
@@ -292,14 +299,11 @@ final class HttpRangeReader extends AbstractRangeReader implements RangeReader {
         final int statusCode = response.statusCode();
         if (statusCode == 401 || statusCode == 403) {
             throw new AccessDeniedException("Authentication failed for URI: " + uri + ", status code: " + statusCode);
+        } else if (statusCode == 404) {
+            throw new NotFoundException("Resource not found: " + uri);
         } else if (statusCode != 200) {
             throw new StorageException("Failed to connect to URI: " + uri + ", status code: " + statusCode);
         }
-    }
-
-    private boolean supportsByteRanges(HttpResponse<Void> response) {
-        List<String> acceptRanges = response.headers().allValues("Accept-Ranges");
-        return acceptRanges.stream().anyMatch("bytes"::equalsIgnoreCase);
     }
 
     private OptionalLong contentLength(HttpResponse<Void> response) {

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/AbstractRangeReaderTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/AbstractRangeReaderTest.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link AbstractRangeReader#readRange(long, int, ByteBuffer)}: EOF handling is delegated to the
+ * backend and {@link RangeReader#size()} is never consulted on the read path.
+ */
+class AbstractRangeReaderTest {
+
+    private static final int SOURCE_SIZE = 100;
+
+    /**
+     * Backend-style fake over an in-memory source: throws RangeNotSatisfiableException for a past-EOF offset and
+     * truncates reads that straddle EOF, like the cloud backends do.
+     */
+    static class FakeRangeReader extends AbstractRangeReader {
+        final AtomicInteger sizeCalls = new AtomicInteger();
+        final byte[] data;
+
+        FakeRangeReader() {
+            this.data = new byte[SOURCE_SIZE];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) i;
+            }
+        }
+
+        @Override
+        protected int readRangeNoFlip(long offset, int length, ByteBuffer target) {
+            if (offset >= data.length) {
+                throw new RangeNotSatisfiableException("offset " + offset + " past EOF");
+            }
+            int available = (int) Math.min(length, data.length - offset);
+            target.put(data, (int) offset, available);
+            return available;
+        }
+
+        @Override
+        public OptionalLong size() {
+            sizeCalls.incrementAndGet();
+            return OptionalLong.of(data.length);
+        }
+
+        @Override
+        public String getSourceIdentifier() {
+            return "fake";
+        }
+
+        @Override
+        public void close() {
+            // nothing to release
+        }
+    }
+
+    @Test
+    void readRangeDoesNotConsultSize() {
+        FakeRangeReader reader = new FakeRangeReader();
+        ByteBuffer target = ByteBuffer.allocate(10);
+        int read = reader.readRange(0, 10, target);
+        assertThat(read).isEqualTo(10);
+        assertThat(reader.sizeCalls).hasValue(0);
+    }
+
+    @Test
+    void readRangePastEofReturnsZeroWithPositionUnchanged() {
+        FakeRangeReader reader = new FakeRangeReader();
+        ByteBuffer target = ByteBuffer.allocate(13);
+        target.position(3);
+        int read = reader.readRange(SOURCE_SIZE + 5, 10, target);
+        assertThat(read).isZero();
+        assertThat(target.position()).isEqualTo(3);
+        assertThat(reader.sizeCalls).hasValue(0);
+    }
+
+    @Test
+    void readRangeAtExactEofReturnsZero() {
+        FakeRangeReader reader = new FakeRangeReader();
+        ByteBuffer target = ByteBuffer.allocate(10);
+        assertThat(reader.readRange(SOURCE_SIZE, 10, target)).isZero();
+    }
+
+    @Test
+    void readRangeStraddlingEofReturnsShortCount() {
+        FakeRangeReader reader = new FakeRangeReader();
+        ByteBuffer target = ByteBuffer.allocate(50);
+        int read = reader.readRange(SOURCE_SIZE - 10, 50, target);
+        assertThat(read).isEqualTo(10);
+        assertThat(target.position()).isEqualTo(10);
+    }
+
+    @Test
+    void validationStillRejectsBadArguments() {
+        FakeRangeReader reader = new FakeRangeReader();
+        ByteBuffer target = ByteBuffer.allocate(10);
+        assertThatThrownBy(() -> reader.readRange(-1, 10, target)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> reader.readRange(0, -1, target)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> reader.readRange(0, 10, null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> reader.readRange(0, 20, target)).isInstanceOf(IllegalArgumentException.class);
+        assertThat(reader.readRange(5, 0, target)).isZero();
+        assertThat(reader.sizeCalls).hasValue(0);
+    }
+}

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/ContentRangeTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/ContentRangeTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.OptionalLong;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ContentRangeTest {
+
+    static Stream<Arguments> headers() {
+        return Stream.of(
+                Arguments.of("bytes 0-9/1234", OptionalLong.of(1234L)),
+                Arguments.of("bytes */5", OptionalLong.of(5L)),
+                Arguments.of("bytes 0-9/*", OptionalLong.empty()),
+                Arguments.of("bytes 0-9", OptionalLong.empty()),
+                Arguments.of("garbage", OptionalLong.empty()),
+                Arguments.of("bytes 0-9/notanumber", OptionalLong.empty()),
+                Arguments.of("", OptionalLong.empty()),
+                Arguments.of(null, OptionalLong.empty()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("headers")
+    void totalOf(String header, OptionalLong expected) {
+        assertThat(ContentRange.totalOf(header)).isEqualTo(expected);
+    }
+}

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/KnownSizeRangeReaderTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/KnownSizeRangeReaderTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Copyright 2026 Multiversio LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.tileverse.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class KnownSizeRangeReaderTest {
+
+    static class CountingReader extends AbstractRangeReader {
+        final AtomicInteger sizeCalls = new AtomicInteger();
+        final AtomicBoolean closed = new AtomicBoolean();
+
+        @Override
+        protected int readRangeNoFlip(long offset, int length, ByteBuffer target) {
+            if (offset >= 64) {
+                throw new RangeNotSatisfiableException("past EOF");
+            }
+            int available = (int) Math.min(length, 64 - offset);
+            target.put(new byte[available]);
+            return available;
+        }
+
+        @Override
+        public OptionalLong size() {
+            sizeCalls.incrementAndGet();
+            return OptionalLong.of(64);
+        }
+
+        @Override
+        public String getSourceIdentifier() {
+            return "counting";
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    @Test
+    void sizeAnswersSeededValueWithoutDelegateCall() throws IOException {
+        CountingReader delegate = new CountingReader();
+        try (RangeReader seeded = KnownSizeRangeReader.of(delegate, 64)) {
+            assertThat(seeded.size()).hasValue(64L);
+            assertThat(delegate.sizeCalls).hasValue(0);
+        }
+    }
+
+    @Test
+    void identityAndReadsForwardToDelegate() throws IOException {
+        CountingReader delegate = new CountingReader();
+        RangeReader seeded = KnownSizeRangeReader.of(delegate, 64);
+
+        assertThat(seeded.getSourceIdentifier()).isEqualTo(delegate.getSourceIdentifier());
+        ByteBuffer target = ByteBuffer.allocate(10);
+        assertThat(seeded.readRange(0, 10, target)).isEqualTo(10);
+
+        seeded.close();
+        assertThat(delegate.closed).isTrue();
+    }
+}

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/file/FileRangeReaderTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/file/FileRangeReaderTest.java
@@ -689,8 +689,8 @@ class FileRangeReaderTest {
 
         @Test
         void permanentCloseSkipsRetryOnRecoverableError() throws Exception {
-            // after close(), readRange raises the closed-state error eagerly via size() which throws
-            // IllegalStateException before reaching readRangeNoFlip.
+            // A permanent close must reject the read immediately, unlike an idle close, which is
+            // transient and triggers the recoverable-error retry with a fresh channel instead.
             try (FileRangeReader r = new FileRangeReader(testFile, Duration.ZERO)) {
 
                 r.readRange(0, 10);
@@ -740,7 +740,7 @@ class FileRangeReaderTest {
         void permanentClosePreventChannelReopen() {
             reader.readRange(0, 10);
             reader.close();
-            // After close, size() throws IllegalStateException eagerly from the readRange entry path.
+            // A permanent close must reject the read immediately, never silently reopening the channel.
             assertThatThrownBy(() -> reader.readRange(0, 10))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("closed");

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/http/HttpRangeReaderTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/http/HttpRangeReaderTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.OptionalLong;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -83,9 +84,20 @@ class HttpRangeReaderTest {
                         .withHeader("Content-Length", String.valueOf(TEST_DATA.length))
                         .withHeader("Accept-Ranges", "bytes")));
 
-        // GET request for entire file (without range header)
+        // Fallback range response for tests that read without stubbing their own range request. The reader
+        // always sends a Range header; this stub simulates a server honoring bytes=0-99, the range the
+        // no-HEAD tests below use.
+        int fallbackStart = 0;
+        int fallbackEnd = 99;
+        byte[] fallbackBytes = Arrays.copyOfRange(TEST_DATA, fallbackStart, fallbackEnd + 1);
         wm.stubFor(get(urlEqualTo(TEST_PATH))
-                .willReturn(aResponse().withStatus(200).withBody(TEST_DATA)));
+                .withHeader("Range", equalTo("bytes=" + fallbackStart + "-" + fallbackEnd))
+                .willReturn(aResponse()
+                        .withStatus(206)
+                        .withHeader(
+                                "Content-Range", "bytes " + fallbackStart + "-" + fallbackEnd + "/" + TEST_DATA.length)
+                        .withHeader("Content-Length", String.valueOf(fallbackBytes.length))
+                        .withBody(fallbackBytes)));
 
         // Individual range request stubs - we'll create these for each test as needed
 
@@ -99,6 +111,57 @@ class HttpRangeReaderTest {
 
         // Verify that HEAD request was made
         wm.verify(headRequestedFor(urlEqualTo(TEST_PATH)));
+    }
+
+    @Test
+    void readOnlyWorkloadIssuesNoHeadRequest() {
+        ByteBuffer target = ByteBuffer.allocate(100);
+        int read = rangeReader.readRange(0, 100, target);
+
+        assertEquals(100, read);
+        wm.verify(0, headRequestedFor(urlEqualTo(TEST_PATH)));
+    }
+
+    @Test
+    void sizeCapturedFromRangeResponseWithoutHead() {
+        rangeReader.readRange(0, 100, ByteBuffer.allocate(100));
+
+        assertEquals(OptionalLong.of(TEST_DATA.length), rangeReader.size());
+        wm.verify(0, headRequestedFor(urlEqualTo(TEST_PATH)));
+    }
+
+    @Test
+    void sizeBeforeAnyReadIssuesExactlyOneHead() {
+        assertEquals(OptionalLong.of(TEST_DATA.length), rangeReader.size());
+        assertEquals(OptionalLong.of(TEST_DATA.length), rangeReader.size());
+        wm.verify(1, headRequestedFor(urlEqualTo(TEST_PATH)));
+    }
+
+    @Test
+    void sizeFallsBackToHeadWhenRangeResponseLacksContentRange() throws IOException {
+        // Distinct path: none of the @BeforeEach TEST_PATH stubs can match it, which avoids the stub-precedence
+        // question that range stubs added for TEST_PATH by other tests must consider.
+        String path = "/no-content-range-on-range-response";
+        byte[] responseBytes = Arrays.copyOfRange(TEST_DATA, 0, 100);
+
+        // A real server violating the spec: 206 with a body but no Content-Range header.
+        wm.stubFor(get(urlEqualTo(path))
+                .withHeader("Range", equalTo("bytes=0-99"))
+                .willReturn(aResponse()
+                        .withStatus(206)
+                        .withHeader("Content-Length", String.valueOf(responseBytes.length))
+                        .withBody(responseBytes)));
+        wm.stubFor(head(urlEqualTo(path))
+                .willReturn(
+                        aResponse().withStatus(200).withHeader("Content-Length", String.valueOf(TEST_DATA.length))));
+
+        URI uri = URI.create("http://localhost:" + wm.getPort() + path);
+        try (RangeReader reader = RangeReaderTestSupport.httpReader(uri)) {
+            reader.readRange(0, 100, ByteBuffer.allocate(100));
+
+            assertEquals(OptionalLong.of(TEST_DATA.length), reader.size());
+            wm.verify(1, headRequestedFor(urlEqualTo(path)));
+        }
     }
 
     @Test
@@ -221,9 +284,10 @@ class HttpRangeReaderTest {
         // Create range response - only including available data
         byte[] responseBytes = Arrays.copyOfRange(TEST_DATA, offset, TEST_DATA.length);
 
-        // Stub the range request
+        // Stub the range request: the client asks for the full range past EOF, and the server
+        // satisfies it with only the available bytes, like a real HTTP server would.
         wm.stubFor(get(urlEqualTo(TEST_PATH))
-                .withHeader("Range", equalTo("bytes=" + offset + "-" + end))
+                .withHeader("Range", equalTo("bytes=" + offset + "-" + (offset + length - 1)))
                 .willReturn(aResponse()
                         .withStatus(206)
                         .withHeader("Content-Range", "bytes " + offset + "-" + end + "/" + TEST_DATA.length)
@@ -245,8 +309,9 @@ class HttpRangeReaderTest {
             assertEquals((byte) ((offset + i) % 256), bytes[i], "Byte mismatch at index " + i);
         }
 
-        // Verify that range request was made with the original range
-        wm.verify(getRequestedFor(urlEqualTo(TEST_PATH)).withHeader("Range", equalTo("bytes=" + offset + "-" + end)));
+        // Verify that the client requested the full range as asked, without pre-truncating at EOF
+        wm.verify(getRequestedFor(urlEqualTo(TEST_PATH))
+                .withHeader("Range", equalTo("bytes=" + offset + "-" + (offset + length - 1))));
     }
 
     @Test
@@ -266,6 +331,19 @@ class HttpRangeReaderTest {
     }
 
     @Test
+    void readPastEofReturnsZeroOn416() {
+        wm.stubFor(get(urlEqualTo(TEST_PATH))
+                .withHeader("Range", matching("bytes=200000-.*"))
+                .willReturn(aResponse().withStatus(416).withHeader("Content-Range", "bytes */" + TEST_DATA.length)));
+
+        ByteBuffer target = ByteBuffer.allocate(100);
+        int read = rangeReader.readRange(200_000, 100, target);
+
+        assertEquals(0, read);
+        assertEquals(0, target.position());
+    }
+
+    @Test
     void testReadWithNegativeOffset() {
         ByteBuffer buff = ByteBuffer.allocate(1);
         assertThatThrownBy(() -> rangeReader.readRange(-1, 10, buff)).isInstanceOf(IllegalArgumentException.class);
@@ -278,20 +356,24 @@ class HttpRangeReaderTest {
     }
 
     @Test
-    void testServerWithoutRangeSupport() {
-        // Create a stub for a server that doesn't support range requests
-        wm.stubFor(head(urlEqualTo("/no-range"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Length", String.valueOf(TEST_DATA.length))
-                        .withHeader("Accept-Ranges", "none")));
+    void rangeIgnoringServerFails() {
+        wm.stubFor(get(urlEqualTo("/ignores-range"))
+                .willReturn(aResponse().withStatus(200).withBody(TEST_DATA)));
+        RangeReader ignoring =
+                RangeReaderTestSupport.httpReader(URI.create(wm.getRuntimeInfo().getHttpBaseUrl() + "/ignores-range"));
 
-        URI noRangeUri = URI.create("http://localhost:" + wm.getPort() + "/no-range");
+        assertThatThrownBy(() -> ignoring.readRange(0, 100))
+                .isInstanceOf(io.tileverse.storage.StorageException.class)
+                .hasMessageContaining("Range");
+    }
 
-        // Should throw when readRange() is called (triggering range support initialization)
-        RangeReader reader = RangeReaderTestSupport.httpReader(noRangeUri);
-        assertThatThrownBy(() -> reader.readRange(0, 100, ByteBuffer.allocate(100)))
-                .isInstanceOf(io.tileverse.storage.StorageException.class);
+    @Test
+    void missingObjectThrowsNotFoundOnFirstRead() {
+        wm.stubFor(get(urlEqualTo("/missing")).willReturn(aResponse().withStatus(404)));
+        RangeReader missing =
+                RangeReaderTestSupport.httpReader(URI.create(wm.getRuntimeInfo().getHttpBaseUrl() + "/missing"));
+
+        assertThatThrownBy(() -> missing.readRange(0, 100)).isInstanceOf(io.tileverse.storage.NotFoundException.class);
     }
 
     @Test
@@ -309,12 +391,6 @@ class HttpRangeReaderTest {
                         .withHeader("Content-Length", String.valueOf(TEST_DATA.length))
                         .withBody(TEST_DATA)));
 
-        wm.stubFor(head(urlEqualTo("/ignore-range"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Length", String.valueOf(TEST_DATA.length))
-                        .withHeader("Accept-Ranges", "bytes")));
-
         URI ignoreRangeUri = URI.create("http://localhost:" + wm.getPort() + "/ignore-range");
 
         // Should throw StorageException when server doesn't support range requests (returns 200 instead of 206)
@@ -331,18 +407,11 @@ class HttpRangeReaderTest {
         int length = 100;
         int end = offset + length - 1;
 
-        // Create a stub for a server that returns an error for the actual range request
+        // Create a stub for a server that returns an error for the actual range request.
+        // 416 is excluded here: it is a past-EOF signal handled elsewhere, not a generic error.
         wm.stubFor(get(urlEqualTo("/error"))
                 .withHeader("Range", equalTo("bytes=" + offset + "-" + end))
-                .willReturn(aResponse()
-                        .withStatus(416) // Range Not Satisfiable
-                        .withBody("Range not satisfiable")));
-
-        wm.stubFor(head(urlEqualTo("/error"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Length", String.valueOf(TEST_DATA.length))
-                        .withHeader("Accept-Ranges", "bytes")));
+                .willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
 
         URI errorUri = URI.create("http://localhost:" + wm.getPort() + "/error");
 

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/it/AbstractRangeReaderIT.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/it/AbstractRangeReaderIT.java
@@ -237,6 +237,12 @@ public abstract class AbstractRangeReaderIT {
             assertEquals(0, explicitEofBuffer.position(), "Position should be 0");
             assertEquals(0, explicitEofBuffer.limit(), "Limit should be 0");
 
+            // Test reading far beyond EOF
+            ByteBuffer beyondEofBuffer = ByteBuffer.allocate(100);
+            int beyondBytesRead = reader.readRange(TEST_FILE_SIZE + 1000, 100, beyondEofBuffer);
+            assertEquals(0, beyondBytesRead, "Reading beyond EOF should return 0 bytes read");
+            assertEquals(0, beyondEofBuffer.position(), "Position should be unchanged");
+
             // Test with zero length explicit buffer
             ByteBuffer explicitZeroBuffer = ByteBuffer.allocate(100);
             int zeroBytesRead = reader.readRange(1000, 0, explicitZeroBuffer);

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/rangereader/adapters/RangeReaderReadableByteChannelTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/rangereader/adapters/RangeReaderReadableByteChannelTest.java
@@ -18,6 +18,8 @@ package io.tileverse.storage.rangereader.adapters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.tileverse.storage.AbstractRangeReader;
+import io.tileverse.storage.RangeNotSatisfiableException;
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.RangeReaderTestSupport;
 import io.tileverse.storage.adapters.RangeReaderReadableByteChannel;
@@ -28,6 +30,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -267,7 +271,7 @@ class RangeReaderReadableByteChannelTest {
             assertThat(result)
                     .contains("RangeReaderReadableByteChannel")
                     .contains("position=0")
-                    .contains("size=" + TEST_FILE_SIZE);
+                    .contains(testFile.toString());
         }
     }
 
@@ -331,6 +335,60 @@ class RangeReaderReadableByteChannelTest {
 
             assertThat(totalBytesRead).isEqualTo(1024 * 1024L);
             assertThat(readCount).isEqualTo(16); // 1MB / 64KB = 16 chunks
+        }
+    }
+
+    static class CountingReader extends AbstractRangeReader {
+        final AtomicInteger sizeCalls = new AtomicInteger();
+        final byte[] data = new byte[64];
+
+        @Override
+        protected int readRangeNoFlip(long offset, int length, ByteBuffer target) {
+            if (offset >= data.length) {
+                throw new RangeNotSatisfiableException("past EOF");
+            }
+            int available = (int) Math.min(length, data.length - offset);
+            target.put(data, (int) offset, available);
+            return available;
+        }
+
+        @Override
+        public OptionalLong size() {
+            sizeCalls.incrementAndGet();
+            return OptionalLong.of(data.length);
+        }
+
+        @Override
+        public String getSourceIdentifier() {
+            return "counting";
+        }
+
+        @Override
+        public void close() {
+            // nothing to release
+        }
+    }
+
+    @Test
+    void sequentialReadToEofNeverConsultsSize() throws IOException {
+        CountingReader reader = new CountingReader();
+        try (RangeReaderReadableByteChannel channel = RangeReaderReadableByteChannel.of(reader)) {
+            ByteBuffer buffer = ByteBuffer.allocate(50);
+            assertThat(channel.read(buffer)).isEqualTo(50);
+            buffer.clear();
+            assertThat(channel.read(buffer)).isEqualTo(14);
+            buffer.clear();
+            assertThat(channel.read(buffer)).isEqualTo(-1);
+            assertThat(reader.sizeCalls).hasValue(0);
+        }
+    }
+
+    @Test
+    void toStringDoesNotConsultSize() throws IOException {
+        CountingReader reader = new CountingReader();
+        try (RangeReaderReadableByteChannel channel = RangeReaderReadableByteChannel.of(reader)) {
+            assertThat(channel.toString()).contains("counting");
+            assertThat(reader.sizeCalls).hasValue(0);
         }
     }
 }

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/rangereader/adapters/RangeReaderSeekableByteChannelTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/rangereader/adapters/RangeReaderSeekableByteChannelTest.java
@@ -340,7 +340,7 @@ class RangeReaderSeekableByteChannelTest {
             assertThat(result)
                     .contains("RangeReaderSeekableByteChannel")
                     .contains("position=0")
-                    .contains("size=" + TEST_FILE_SIZE);
+                    .contains(testFile.toString());
         }
     }
 

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/tck/StorageTCK.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/tck/StorageTCK.java
@@ -189,6 +189,22 @@ public abstract class StorageTCK {
         }
     }
 
+    @Test
+    void openRangeReaderFromListingEntrySeedsSize() throws IOException {
+        requireWrites();
+        byte[] data = "0123456789".getBytes(StandardCharsets.UTF_8);
+        storage.put("seeded.bin", data);
+        StorageEntry.File entry = storage.stat("seeded.bin").orElseThrow();
+        try (RangeReader rr = storage.openRangeReader(entry)) {
+            assertThat(rr.size()).hasValue((long) data.length);
+            ByteBuffer buf = rr.readRange(2, 4);
+            buf.flip();
+            byte[] out = new byte[buf.remaining()];
+            buf.get(out);
+            assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("2345");
+        }
+    }
+
     /**
      * Round-trip a payload large enough to cross the multipart upload threshold (8 MiB for S3 / GCS, configurable for
      * Azure) and the CRT async client's default {@code minimumPartSize} (8 MiB), then read it back three ways:

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorage.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorage.java
@@ -308,9 +308,6 @@ final class GoogleCloudStorage implements Storage {
     @Override
     public RangeReader openRangeReader(String key) {
         requireOpen();
-        if (stat(key).isEmpty()) {
-            throw new NotFoundException("Blob not found: gs://" + location.bucket() + "/" + location.resolve(key));
-        }
         return new GoogleCloudStorageRangeReader(
                 handle.client(), location.bucket(), location.resolve(key), userProject);
     }

--- a/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReader.java
+++ b/tileverse-storage/gcs/src/main/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReader.java
@@ -22,6 +22,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.StorageException;
 import io.tileverse.storage.AbstractRangeReader;
 import io.tileverse.storage.NotFoundException;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -44,46 +46,37 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 final class GoogleCloudStorageRangeReader extends AbstractRangeReader implements RangeReader {
 
-    @SuppressWarnings("unused")
     private final Storage storage;
-
     private final String bucket;
     private final String objectName;
+    private final Optional<String> userProject;
 
-    private Blob blob;
+    private final AtomicReference<OptionalLong> contentLength = new AtomicReference<>();
 
     /**
      * Creates a new GoogleCloudStorageRangeReader for the specified GCS object.
      *
+     * <p>Construction performs no I/O. A missing object is reported by the first {@link #readRange(long, int)} or
+     * {@link #size()} call instead of at construction time.
+     *
      * @param storage The GCS Storage client to use
      * @param bucket The GCS bucket name
      * @param objectName The GCS object name
-     * @throws io.tileverse.storage.StorageException If a storage error occurs
+     * @param userProject the project to bill for a Requester Pays bucket, if any
      */
     GoogleCloudStorageRangeReader(Storage storage, String bucket, String objectName, Optional<String> userProject) {
         this.storage = requireNonNull(storage, "Storage client cannot be null");
         this.bucket = requireNonNull(bucket, "Bucket name cannot be null");
         this.objectName = requireNonNull(objectName, "Object name cannot be null");
-        BlobId blobId = BlobId.of(bucket, objectName);
-        List<BlobGetOption> getOpts = new ArrayList<>();
-        userProject.ifPresent(p -> getOpts.add(BlobGetOption.userProject(p)));
-        try {
-            this.blob = storage.get(blobId, getOpts.toArray(BlobGetOption[]::new));
-        } catch (StorageException e) {
-            throw SdkExceptionMapper.map(e, objectName);
-        }
-
-        if (blob == null || !blob.exists()) {
-            throw new NotFoundException("GCS object not found: gs://" + bucket + "/" + objectName);
-        }
+        this.userProject = requireNonNull(userProject, "userProject cannot be null");
     }
 
     @Override
     protected int readRangeNoFlip(final long offset, final int actualLength, ByteBuffer target) {
         try {
             final long start = System.nanoTime();
-            // Read the specified range from GCS using readChannelWithResponse
-            try (ReadChannel reader = blob.reader()) {
+            // Read the specified range from GCS, always against the current object generation
+            try (ReadChannel reader = storage.reader(BlobId.of(bucket, objectName), readOptions())) {
                 reader.seek(offset);
                 reader.limit(offset + actualLength);
                 int totalBytesRead = 0;
@@ -109,9 +102,32 @@ final class GoogleCloudStorageRangeReader extends AbstractRangeReader implements
         }
     }
 
+    private BlobSourceOption[] readOptions() {
+        return userProject
+                .map(p -> new BlobSourceOption[] {BlobSourceOption.userProject(p)})
+                .orElseGet(() -> new BlobSourceOption[0]);
+    }
+
     @Override
     public OptionalLong size() {
-        if (blob == null || !blob.exists()) {
+        OptionalLong known = contentLength.get();
+        if (known == null) {
+            known = contentLength.updateAndGet(current -> current != null ? current : fetchSize());
+        }
+        return known;
+    }
+
+    private OptionalLong fetchSize() {
+        List<BlobGetOption> getOpts = new ArrayList<>();
+        getOpts.add(BlobGetOption.fields(Storage.BlobField.SIZE));
+        userProject.ifPresent(p -> getOpts.add(BlobGetOption.userProject(p)));
+        Blob blob;
+        try {
+            blob = storage.get(BlobId.of(bucket, objectName), getOpts.toArray(BlobGetOption[]::new));
+        } catch (StorageException e) {
+            throw SdkExceptionMapper.map(e, objectName);
+        }
+        if (blob == null) {
             throw new NotFoundException("GCS object not found: gs://" + bucket + "/" + objectName);
         }
         Long size = blob.getSize();

--- a/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReaderTest.java
+++ b/tileverse-storage/gcs/src/test/java/io/tileverse/storage/gcs/GoogleCloudStorageRangeReaderTest.java
@@ -15,6 +15,7 @@
  */
 package io.tileverse.storage.gcs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,6 +34,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.StorageException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -75,20 +77,10 @@ class GoogleCloudStorageRangeReaderTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        BlobId blobId = BlobId.of(BUCKET, OBJECT_NAME);
-
         // Reset seek position
         currentSeekPosition = 0;
 
-        // Make mocks lenient for this test class to avoid unnecessary stubbing errors
-        lenient().when(storage.get(eq(blobId), any(BlobGetOption[].class))).thenReturn(blob);
-        lenient().when(blob.exists()).thenReturn(true);
-        lenient().when(blob.getSize()).thenReturn((long) CONTENT_LENGTH);
-
-        // Setup mock for blob.reader()
-        lenient().when(blob.reader()).thenReturn(readChannel);
-
-        // Setup mock for seek operation
+        // Kept lenient: not every test triggers a read.
         lenient()
                 .doAnswer(invocation -> {
                     currentSeekPosition = invocation.getArgument(0);
@@ -97,7 +89,7 @@ class GoogleCloudStorageRangeReaderTest {
                 .when(readChannel)
                 .seek(any(Long.class));
 
-        // Setup mock for ReadChannel behavior
+        // Kept lenient: not every test triggers a read.
         lenient().when(readChannel.read(any(ByteBuffer.class))).thenAnswer(invocation -> {
             ByteBuffer buffer = invocation.getArgument(0);
             int remaining = buffer.remaining();
@@ -116,18 +108,70 @@ class GoogleCloudStorageRangeReaderTest {
             return bytesToRead;
         });
 
-        // Create the reader
+        // Building the shared fixture here touches no mock: construction performs no I/O.
         reader = new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty());
+    }
+
+    /** Stubs {@code storage.reader(...)} to serve reads through the shared {@link #readChannel} mock. */
+    private void stubReader() {
+        when(storage.reader(any(BlobId.class), any(BlobSourceOption[].class))).thenReturn(readChannel);
+    }
+
+    /** Stubs {@code storage.get(...)} to resolve {@code size()} to {@link #CONTENT_LENGTH}. */
+    private void stubSize() {
+        when(storage.get(any(BlobId.class), any(BlobGetOption[].class))).thenReturn(blob);
+        when(blob.getSize()).thenReturn((long) CONTENT_LENGTH);
+    }
+
+    @Test
+    void constructorMakesNoRequests() {
+        new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty());
+        verifyNoInteractions(storage);
+    }
+
+    @Test
+    void notFoundThrownOnFirstReadNotAtConstruction() {
+        GoogleCloudStorageRangeReader missing =
+                new GoogleCloudStorageRangeReader(storage, BUCKET, "missing", Optional.empty());
+        StorageException notFound = new StorageException(404, "Not Found");
+        when(storage.reader(any(BlobId.class), any(BlobSourceOption[].class))).thenThrow(notFound);
+
+        assertThatThrownBy(() -> missing.readRange(0, 10)).isInstanceOf(io.tileverse.storage.NotFoundException.class);
+    }
+
+    @Test
+    void sizeIsLazyAndMemoized() {
+        when(storage.get(any(BlobId.class), any(BlobGetOption[].class))).thenReturn(blob);
+        when(blob.getSize()).thenReturn(12345L);
+
+        GoogleCloudStorageRangeReader lazy =
+                new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty());
+        verifyNoInteractions(storage);
+
+        assertThat(lazy.size()).hasValue(12345L);
+        assertThat(lazy.size()).hasValue(12345L);
+        verify(storage, times(1)).get(any(BlobId.class), any(BlobGetOption[].class));
+    }
+
+    @Test
+    void sizeThrowsNotFoundForMissingObject() {
+        when(storage.get(any(BlobId.class), any(BlobGetOption[].class))).thenReturn(null);
+        GoogleCloudStorageRangeReader missing =
+                new GoogleCloudStorageRangeReader(storage, BUCKET, "missing", Optional.empty());
+
+        assertThatThrownBy(missing::size).isInstanceOf(io.tileverse.storage.NotFoundException.class);
     }
 
     @Test
     void testGetSize() {
+        stubSize();
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
         verify(storage, times(1)).get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class));
     }
 
     @Test
     void testReadEntireFile() throws IOException {
+        stubReader();
         ByteBuffer buffer = reader.readRange(0, CONTENT_LENGTH);
         buffer.flip();
 
@@ -138,12 +182,13 @@ class GoogleCloudStorageRangeReaderTest {
 
         assertArrayEquals(TEST_DATA, bytes);
 
-        verify(blob).reader();
+        verify(storage).reader(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobSourceOption[].class));
         verify(readChannel).seek(0L);
     }
 
     @Test
     void testReadRange() throws IOException {
+        stubReader();
         int offset = 100;
         int length = 500;
 
@@ -158,12 +203,13 @@ class GoogleCloudStorageRangeReaderTest {
         byte[] expectedBytes = Arrays.copyOfRange(TEST_DATA, offset, offset + length);
         assertArrayEquals(expectedBytes, bytes);
 
-        verify(blob).reader();
+        verify(storage).reader(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobSourceOption[].class));
         verify(readChannel).seek((long) offset);
     }
 
     @Test
     void testReadRangeBeyondEnd() throws IOException {
+        stubReader();
         int offset = CONTENT_LENGTH - 200;
         int length = 500; // Beyond the end
         int actualLength = 200; // Should be truncated to end of file
@@ -180,7 +226,7 @@ class GoogleCloudStorageRangeReaderTest {
         byte[] expectedBytes = Arrays.copyOfRange(TEST_DATA, offset, CONTENT_LENGTH);
         assertArrayEquals(expectedBytes, bytes);
 
-        verify(blob).reader();
+        verify(storage).reader(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobSourceOption[].class));
         verify(readChannel).seek((long) offset);
     }
 
@@ -192,7 +238,7 @@ class GoogleCloudStorageRangeReaderTest {
         assertEquals(0, buffer.remaining());
 
         // Should not make any API calls for zero length
-        verify(blob, never()).reader();
+        verify(storage, never()).reader(any(BlobId.class), any(BlobSourceOption[].class));
     }
 
     @Test
@@ -205,50 +251,23 @@ class GoogleCloudStorageRangeReaderTest {
         assertThatThrownBy(() -> reader.readRange(0, -1)).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @SuppressWarnings("resource")
-    @Test
-    void testObjectExistsReturnsFalse() {
-        // Override the default behavior for this specific test
-        when(blob.exists()).thenReturn(false);
-
-        assertThatThrownBy(
-                        () -> new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, Optional.empty()).size())
-                .isInstanceOf(io.tileverse.storage.NotFoundException.class);
-    }
-
     @Test
     void testStorageExceptionDuringRead() {
-        // Override the default behavior for this specific test
-        when(blob.reader()).thenThrow(new StorageException(500, "Storage error"));
+        when(storage.reader(any(BlobId.class), any(BlobSourceOption[].class)))
+                .thenThrow(new StorageException(500, "Storage error"));
 
         assertThatThrownBy(() -> reader.readRange(0, 100)).isInstanceOf(io.tileverse.storage.StorageException.class);
     }
 
     @Test
     void testUnexpectedContentLength() throws IOException {
-        // This test is no longer applicable with the new streaming API
-        // The ReadChannel approach handles partial reads naturally
-        // So we can remove this test or adapt it for different error conditions
-
         // Test reading when channel returns -1 (EOF) immediately
-        when(blob.reader()).thenReturn(readChannel);
+        stubReader();
         when(readChannel.read(any(ByteBuffer.class))).thenReturn(-1);
 
         ByteBuffer buffer = reader.readRange(0, 100);
         buffer.flip();
         assertEquals(0, buffer.remaining(), "Should return empty buffer when EOF reached immediately");
-    }
-
-    @Test
-    void testGetSizeFromCachedValue() {
-        // First call should query the blob
-        assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
-        verify(storage, times(1)).get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class));
-
-        // Second call should use cached value
-        assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
-        verify(storage, times(1))
-                .get(eq(BlobId.of(BUCKET, OBJECT_NAME)), any(BlobGetOption[].class)); // Still only one call
     }
 
     @Test
@@ -258,6 +277,8 @@ class GoogleCloudStorageRangeReaderTest {
         assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, null, OBJECT_NAME, Optional.empty()))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, BUCKET, null, Optional.empty()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new GoogleCloudStorageRangeReader(storage, BUCKET, OBJECT_NAME, null))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3RangeReader.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3RangeReader.java
@@ -16,12 +16,14 @@
 package io.tileverse.storage.s3;
 
 import io.tileverse.storage.AbstractRangeReader;
+import io.tileverse.storage.ContentRange;
 import io.tileverse.storage.NotFoundException;
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.StorageException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
@@ -81,38 +83,22 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
     private final S3Reference s3Location;
     private final boolean requesterPays;
 
-    private final OptionalLong contentLength;
+    private final AtomicReference<OptionalLong> contentLength = new AtomicReference<>();
 
     /**
      * Creates a new S3RangeReader for the specified S3 object.
      *
+     * <p>Construction performs no I/O. A missing object is reported by the first {@link #readRange(long, int)} or
+     * {@link #size()} call instead of at construction time.
+     *
      * @param s3Client The S3 client to use
      * @param s3Location The S3 reference (bucket + key)
      * @param requesterPays when {@code true}, every request adds {@code x-amz-request-payer: requester}
-     * @throws StorageException If a storage error occurs
      */
     S3RangeReader(S3Client s3Client, S3Reference s3Location, boolean requesterPays) {
         this.s3Client = Objects.requireNonNull(s3Client, "S3Client cannot be null");
         this.s3Location = Objects.requireNonNull(s3Location, "S3Location cannot be null");
         this.requesterPays = requesterPays;
-        // Eager HEAD: throw NotFoundException at construction time so callers don't get
-        // mid-stream failures, and cache the content length for subsequent size() calls.
-        try {
-            HeadObjectRequest.Builder headBuilder =
-                    HeadObjectRequest.builder().bucket(s3Location.bucket()).key(s3Location.key());
-            if (requesterPays) {
-                headBuilder.requestPayer(RequestPayer.REQUESTER);
-            }
-            HeadObjectResponse headResponse = s3Client.headObject(headBuilder.build());
-            Long size = headResponse.contentLength();
-            this.contentLength = size == null ? OptionalLong.empty() : OptionalLong.of(size);
-        } catch (NoSuchKeyException e) {
-            throw new NotFoundException("S3 object does not exist: s3://" + s3Location, e);
-        } catch (S3Exception e) {
-            throw S3ExceptionMapper.map(e, s3Location.key());
-        } catch (SdkException e) {
-            throw new StorageException("Failed to access S3 object " + s3Location + ": " + e.getMessage(), e);
-        }
     }
 
     @Override
@@ -127,15 +113,16 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
                 rangeBuilder.requestPayer(RequestPayer.REQUESTER);
             }
             ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(rangeBuilder.build());
-            if (objectBytes.response().contentLength() != actualLength) {
-                throw new StorageException("Unexpected content length: got "
-                        + objectBytes.response().contentLength()
-                        + ", expected "
-                        + actualLength);
-            }
+            captureSizeFrom(objectBytes.response());
             byte[] data = objectBytes.asByteArray();
+            if (data.length > actualLength) {
+                throw new StorageException(
+                        "Server returned more data than requested: got " + data.length + ", requested " + actualLength);
+            }
             target.put(data);
             return data.length;
+        } catch (NoSuchKeyException e) {
+            throw new NotFoundException("S3 object does not exist: s3://" + s3Location, e);
         } catch (S3Exception e) {
             throw S3ExceptionMapper.map(e, s3Location.key());
         } catch (SdkException e) {
@@ -145,7 +132,43 @@ final class S3RangeReader extends AbstractRangeReader implements RangeReader {
 
     @Override
     public OptionalLong size() {
-        return contentLength;
+        OptionalLong known = contentLength.get();
+        if (known == null) {
+            known = contentLength.updateAndGet(current -> current != null ? current : fetchSize());
+        }
+        return known;
+    }
+
+    private OptionalLong fetchSize() {
+        try {
+            HeadObjectRequest.Builder headBuilder =
+                    HeadObjectRequest.builder().bucket(s3Location.bucket()).key(s3Location.key());
+            if (requesterPays) {
+                headBuilder.requestPayer(RequestPayer.REQUESTER);
+            }
+            HeadObjectResponse headResponse = s3Client.headObject(headBuilder.build());
+            Long size = headResponse.contentLength();
+            return size == null ? OptionalLong.empty() : OptionalLong.of(size);
+        } catch (NoSuchKeyException e) {
+            throw new NotFoundException("S3 object does not exist: s3://" + s3Location, e);
+        } catch (S3Exception e) {
+            throw S3ExceptionMapper.map(e, s3Location.key());
+        } catch (SdkException e) {
+            throw new StorageException("Failed to access S3 object " + s3Location + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Captures the total object size from a range response's {@code Content-Range} header, when not already known. Lets
+     * a read that happens before any {@link #size()} call populate the memoized value for free, without an extra HEAD
+     * request.
+     */
+    private void captureSizeFrom(GetObjectResponse response) {
+        if (contentLength.get() != null) {
+            return;
+        }
+        ContentRange.totalOf(response.contentRange())
+                .ifPresent(total -> contentLength.compareAndSet(null, OptionalLong.of(total)));
     }
 
     @Override

--- a/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3Storage.java
+++ b/tileverse-storage/s3/src/main/java/io/tileverse/storage/s3/S3Storage.java
@@ -18,7 +18,6 @@ package io.tileverse.storage.s3;
 import io.tileverse.storage.CopyOptions;
 import io.tileverse.storage.DeleteResult;
 import io.tileverse.storage.ListOptions;
-import io.tileverse.storage.NotFoundException;
 import io.tileverse.storage.PreconditionFailedException;
 import io.tileverse.storage.PresignWriteOptions;
 import io.tileverse.storage.RangeReader;
@@ -338,10 +337,8 @@ final class S3Storage implements Storage {
     public RangeReader openRangeReader(String key) {
         requireOpen();
         String fullKey = resolve(key);
-        if (stat(key).isEmpty()) {
-            throw new NotFoundException("Object not found: s3://" + ref.bucket() + "/" + fullKey);
-        }
         // Reuse our cached S3Client (which already has the right endpoint, region, credentials).
+        // Opening issues no request; a missing key is reported by the first read or size() call.
         return new S3RangeReader(handle.client(), new S3Reference(null, ref.bucket(), fullKey, null), requesterPays);
     }
 

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3OvertureMapsLiveIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3OvertureMapsLiveIT.java
@@ -159,10 +159,10 @@ class S3OvertureMapsLiveIT {
     }
 
     @Test
-    void openRangeReaderThrowsNotFoundForMissingKey() throws IOException {
-        try (Storage storage = StorageFactory.open(baseUri, anonymous())) {
-            assertThatThrownBy(() -> storage.openRangeReader("does/not/exist.parquet"))
-                    .isInstanceOf(NotFoundException.class);
+    void openRangeReaderThrowsNotFoundOnFirstReadForMissingKey() throws IOException {
+        try (Storage storage = StorageFactory.open(baseUri, anonymous());
+                RangeReader reader = storage.openRangeReader("does/not/exist.parquet")) {
+            assertThatThrownBy(() -> reader.readRange(0, 4)).isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderTest.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RangeReaderTest.java
@@ -26,16 +26,20 @@ import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.tileverse.storage.NotFoundException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -43,6 +47,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 // Use LENIENT strictness to avoid unnecessary stubbing errors in tests
 @ExtendWith(MockitoExtension.class)
@@ -78,11 +84,6 @@ class S3RangeReaderTest {
 
     @BeforeEach
     void setUp() {
-        // Make mocks lenient for this test class to avoid unnecessary stubbing errors
-        lenient().when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
-        lenient().when(headObjectResponse.contentLength()).thenReturn((long) CONTENT_LENGTH);
-        lenient().when(headObjectResponse.lastModified()).thenReturn(Instant.EPOCH);
-
         // Setup mock behavior for GET request - explicitly use GetObjectRequest overload
         lenient()
                 .when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
@@ -115,8 +116,10 @@ class S3RangeReaderTest {
             int end = Integer.parseInt(rangeParts[1]);
             int length = end - start + 1;
 
-            // Return the requested range
-            return Arrays.copyOfRange(TEST_DATA, start, start + length);
+            // A real object store truncates a range that extends past the object's actual end
+            // instead of padding it. The mock matches that behavior.
+            int availableEnd = Math.min(start + length, TEST_DATA.length);
+            return Arrays.copyOfRange(TEST_DATA, start, availableEnd);
         });
 
         // Create the reader directly via the package-private constructor.
@@ -125,16 +128,74 @@ class S3RangeReaderTest {
         reader = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null), false);
     }
 
+    /** Stubs the HEAD response used by {@code size()}. Called only by tests that exercise size(). */
+    private void stubHeadObject() {
+        lenient().when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
+        lenient().when(headObjectResponse.contentLength()).thenReturn((long) CONTENT_LENGTH);
+        lenient().when(headObjectResponse.lastModified()).thenReturn(Instant.EPOCH);
+    }
+
+    @Test
+    void testConstructorMakesNoRequests() {
+        new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null), false);
+        verifyNoInteractions(s3Client);
+    }
+
     @Test
     void testGetSize() {
+        stubHeadObject();
         assertEquals(CONTENT_LENGTH, reader.size().getAsLong());
         verify(s3Client, times(1)).headObject(any(HeadObjectRequest.class));
     }
 
     @Test
-    void testReadEntireFile() {
-        when(getObjectResponse.contentLength()).thenReturn((long) CONTENT_LENGTH);
+    void testSizeIsLazyAndMemoized() {
+        stubHeadObject();
+        S3RangeReader lazy = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null), false);
+        verify(s3Client, never()).headObject((HeadObjectRequest) any(HeadObjectRequest.class));
 
+        assertEquals(OptionalLong.of(CONTENT_LENGTH), lazy.size());
+        assertEquals(OptionalLong.of(CONTENT_LENGTH), lazy.size());
+        verify(s3Client, times(1)).headObject((HeadObjectRequest) any(HeadObjectRequest.class));
+    }
+
+    @Test
+    void testSizeThrowsNotFoundForMissingKey() {
+        S3RangeReader missing = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, "missing", null), false);
+        when(s3Client.headObject((HeadObjectRequest) any(HeadObjectRequest.class)))
+                .thenThrow(NoSuchKeyException.builder().message("no such key").build());
+
+        assertThatThrownBy(missing::size).isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void testSizeCapturedFromRangeResponseWithoutHead() {
+        byte[] slice = Arrays.copyOfRange(TEST_DATA, 0, 10);
+        GetObjectResponse response = GetObjectResponse.builder()
+                .contentLength(10L)
+                .contentRange("bytes 0-9/" + CONTENT_LENGTH)
+                .build();
+        when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
+                .thenReturn(ResponseBytes.fromByteArray(response, slice));
+
+        S3RangeReader lazy = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, KEY, null), false);
+        lazy.readRange(0, 10);
+
+        assertEquals(OptionalLong.of(CONTENT_LENGTH), lazy.size());
+        verify(s3Client, never()).headObject((HeadObjectRequest) any(HeadObjectRequest.class));
+    }
+
+    @Test
+    void testNotFoundThrownOnFirstReadNotAtConstruction() {
+        S3RangeReader missing = new S3RangeReader(s3Client, new S3Reference(null, BUCKET, "missing", null), false);
+        when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
+                .thenThrow(NoSuchKeyException.builder().message("no such key").build());
+
+        assertThatThrownBy(() -> missing.readRange(0, 10)).isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void testReadEntireFile() {
         ByteBuffer buffer = reader.readRange(0, CONTENT_LENGTH);
         buffer.flip();
 
@@ -153,7 +214,6 @@ class S3RangeReaderTest {
     void testReadRange() {
         int offset = 100;
         int length = 500;
-        when(getObjectResponse.contentLength()).thenReturn((long) length);
 
         ByteBuffer buffer = reader.readRange(offset, length);
         buffer.flip();
@@ -174,12 +234,11 @@ class S3RangeReaderTest {
     void testReadRangeBeyondEnd() {
         int offset = CONTENT_LENGTH - 200;
         int length = 500; // Beyond the end
-        when(getObjectResponse.contentLength()).thenReturn(200L);
 
         ByteBuffer buffer = reader.readRange(offset, length);
         buffer.flip();
 
-        // Should only return up to the end of the file
+        // The server, not the client, truncates the response to the available data
         assertEquals(200, buffer.remaining());
 
         byte[] bytes = new byte[buffer.remaining()];
@@ -188,8 +247,9 @@ class S3RangeReaderTest {
         byte[] expectedBytes = Arrays.copyOfRange(TEST_DATA, offset, CONTENT_LENGTH);
         assertArrayEquals(expectedBytes, bytes);
 
+        // The client requests the full range as asked; it does not pre-truncate at EOF
         verify(s3Client).getObjectAsBytes((GetObjectRequest) argThat(request -> request instanceof GetObjectRequest
-                && ((GetObjectRequest) request).range().equals("bytes=" + offset + "-" + (CONTENT_LENGTH - 1))));
+                && ((GetObjectRequest) request).range().equals("bytes=" + offset + "-" + (offset + length - 1))));
     }
 
     @Test
@@ -223,9 +283,14 @@ class S3RangeReaderTest {
     }
 
     @Test
-    void testS3UnexpectedContentLength() {
-        // Override the default behavior for this specific test
-        when(getObjectResponse.contentLength()).thenReturn(50L); // Wrong content length
+    void testS3ReturnsMoreThanRequested() {
+        // A server that ignores the requested range and returns more data than asked for is a
+        // storage error, not an EOF condition.
+        byte[] tooMuch = Arrays.copyOfRange(TEST_DATA, 0, 150);
+        GetObjectResponse oversizedResponse =
+                GetObjectResponse.builder().contentLength((long) tooMuch.length).build();
+        when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
+                .thenReturn(ResponseBytes.fromByteArray(oversizedResponse, tooMuch));
 
         assertThatThrownBy(() -> reader.readRange(0, 100)).isInstanceOf(io.tileverse.storage.StorageException.class);
     }
@@ -233,5 +298,37 @@ class S3RangeReaderTest {
     @Test
     void testGetSourceIdentifier() {
         assertEquals("s3://%s/%s".formatted(BUCKET, KEY), reader.getSourceIdentifier());
+    }
+
+    @Test
+    void testReadStraddlingEofReturnsShortCount() {
+        // The server answers a range that runs past EOF with only the available bytes.
+        byte[] available = Arrays.copyOfRange(TEST_DATA, CONTENT_LENGTH - 10, CONTENT_LENGTH);
+        GetObjectResponse shortResponse = GetObjectResponse.builder()
+                .contentLength((long) available.length)
+                .build();
+        when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
+                .thenReturn(ResponseBytes.fromByteArray(shortResponse, available));
+
+        ByteBuffer target = ByteBuffer.allocate(100);
+        int read = reader.readRange(CONTENT_LENGTH - 10, 100, target);
+
+        assertEquals(10, read);
+    }
+
+    @Test
+    void testReadPastEofReturnsZero() {
+        AwsServiceException invalidRange = S3Exception.builder()
+                .statusCode(416)
+                .message("Requested Range Not Satisfiable")
+                .build();
+        when(s3Client.getObjectAsBytes((GetObjectRequest) any(GetObjectRequest.class)))
+                .thenThrow(invalidRange);
+
+        ByteBuffer target = ByteBuffer.allocate(100);
+        int read = reader.readRange(CONTENT_LENGTH + 5, 100, target);
+
+        assertEquals(0, read);
+        assertEquals(0, target.position());
     }
 }

--- a/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
+++ b/tileverse-storage/s3/src/test/java/io/tileverse/storage/s3/S3RequesterPaysIT.java
@@ -181,7 +181,7 @@ class S3RequesterPaysIT {
             reader.readRange(0, 4, buf);
         }
 
-        // openRangeReader does a stat() (HEAD) then constructs S3RangeReader (HEAD) and reads (GET).
+        // openRangeReader issues no request; the range read above is the only captured call (GET).
         assertThat(capturedRequests).isNotEmpty();
         assertThat(capturedRequests)
                 .allSatisfy(req -> assertThat(headerValue(req, REQUEST_PAYER_HEADER))


### PR DESCRIPTION
Opening a `RangeReader` no longer performs any backend request on the remote backends (S3, Azure, GCS, HTTP): the existence prechecks and constructor HEAD/properties fetches are gone, and a missing object is reported by the first read or size() call. The local file backend keeps its cheap existence check at open.

EOF handling moves from a size()-based clamp into the backends, which answer past-EOF requests natively (416 translated to 0 bytes read, short responses returned as-is). `size()` is fetched lazily once and captured for free from `Content-Range` response headers when a read happens first; HTTP drops its `Accept-Ranges` preflight HEAD entirely.

`Storage.openRangeReader(StorageEntry.File)` seeds the size from a listing entry, letting datasets of many files be opened with zero metadata requests. Channel adapters detect end of stream from read results instead of asking for the size.

on-behalf-of: @camptocamp <info@camptocamp.com>