### PR TITLE
refactor(storage): move channel adapters into the adapters package

### DIFF
--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/ReadableByteChannelDataInput.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/ReadableByteChannelDataInput.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import java.io.DataInput;
 import java.io.EOFException;

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/SeekableByteChannelDataInput.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/SeekableByteChannelDataInput.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import java.io.DataInput;
 import java.io.IOException;

--- a/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/SeekableByteChannelImageInputStream.java
+++ b/tileverse-storage/core/src/main/java/io/tileverse/storage/adapters/SeekableByteChannelImageInputStream.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderReadableByteChannelTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderReadableByteChannelTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.storage.rangereader.adapters;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,7 +22,6 @@ import io.tileverse.storage.AbstractRangeReader;
 import io.tileverse.storage.RangeNotSatisfiableException;
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.RangeReaderTestSupport;
-import io.tileverse.storage.adapters.RangeReaderReadableByteChannel;
 import io.tileverse.storage.it.TestUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannelIntegrationTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannelIntegrationTest.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.storage.rangereader.adapters;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.RangeReaderTestSupport;
-import io.tileverse.storage.adapters.RangeReaderSeekableByteChannel;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannelTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/RangeReaderSeekableByteChannelTest.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.storage.rangereader.adapters;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.tileverse.storage.RangeReader;
 import io.tileverse.storage.RangeReaderTestSupport;
-import io.tileverse.storage.adapters.RangeReaderSeekableByteChannel;
 import io.tileverse.storage.it.TestUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/ReadableByteChannelDataInputTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/ReadableByteChannelDataInputTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/SeekableByteChannelDataInputTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/SeekableByteChannelDataInputTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/SeekableByteChannelImageInputStreamTest.java
+++ b/tileverse-storage/core/src/test/java/io/tileverse/storage/adapters/SeekableByteChannelImageInputStreamTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.tileverse.io;
+package io.tileverse.storage.adapters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
Group the channel-to-`DataInput`/`ImageInputStream` adapters with the `RangeReader`-to-channel adapters in `io.tileverse.storage.adapters`. The full bridge from storage to standard Java IO now lives in one package, and `io.tileverse.io` keeps only IO primitives such as the buffer pool and byte ranges.

on-behalf-of: @camptocamp <info@camptocamp.com>